### PR TITLE
auto: add tags browsing pages for content discovery

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,6 +7,7 @@ const year = new Date().getFullYear();
     <div class="flex items-center justify-between text-text-muted text-sm font-mono">
       <span>&copy; {year} SOFT CAT .ai</span>
       <span class="flex items-center gap-3 text-xs">
+        <a href="/tags" class="hover:text-neon-cyan transition-colors">tags</a>
         <a href="/feed.xml" class="hover:text-neon-amber transition-colors" title="RSS Feed">RSS</a>
         <a href="/status" class="hover:text-neon-green transition-colors"><span class="text-neon-green">&#9679;</span> systems nominal</a>
       </span>

--- a/src/pages/news-and-updates/index.astro
+++ b/src/pages/news-and-updates/index.astro
@@ -45,7 +45,13 @@ const entries = (await getCollection('news-and-updates'))
             {entry.data.tags.length > 0 && (
               <div class="flex flex-wrap gap-1.5 mt-3">
                 {entry.data.tags.map((tag) => (
-                  <span class="px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono text-text-muted">{tag}</span>
+                  <a
+                    href={`/tags/${tag}`}
+                    class="px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono text-text-muted hover:text-neon-cyan transition-colors"
+                    onclick="event.stopPropagation()"
+                  >
+                    {tag}
+                  </a>
                 ))}
               </div>
             )}

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,172 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const news = (await getCollection('news-and-updates')).filter((e) => !e.data.draft);
+  const thoughts = (await getCollection('thoughts')).filter((e) => !e.data.draft);
+  const tools = (await getCollection('tools')).filter((e) => !e.data.draft);
+
+  const allTags = new Set([
+    ...news.flatMap((e) => e.data.tags),
+    ...thoughts.flatMap((e) => e.data.tags),
+    ...tools.flatMap((e) => e.data.tags),
+  ]);
+
+  return [...allTags].map((tag) => ({
+    params: { tag },
+    props: {
+      tag,
+      newsEntries: news.filter((e) => e.data.tags.includes(tag)),
+      thoughtEntries: thoughts.filter((e) => e.data.tags.includes(tag)),
+      toolEntries: tools.filter((e) => e.data.tags.includes(tag)),
+    },
+  }));
+}
+
+const { tag, newsEntries, thoughtEntries, toolEntries } = Astro.props;
+const total = newsEntries.length + thoughtEntries.length + toolEntries.length;
+---
+
+<BaseLayout title={`#${tag}`} description={`All SOFT CAT .ai content tagged ${tag}.`}>
+  <div class="max-w-3xl mx-auto px-6 py-16">
+    <header class="mb-12">
+      <a href="/tags" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; all tags</a>
+      <h1 class="font-mono text-3xl font-bold text-text-bright glow-cyan">#{tag}</h1>
+      <p class="text-text-muted mt-2">{total} {total === 1 ? 'post' : 'posts'} tagged {tag}.</p>
+    </header>
+
+    <div class="space-y-10">
+      {newsEntries.length > 0 && (
+        <section>
+          <h2 class="font-mono text-xs text-neon-green uppercase tracking-widest mb-4">News & Updates</h2>
+          <div class="grid gap-4">
+            {newsEntries
+              .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+              .map((entry) => (
+                <a
+                  href={`/news-and-updates/${entry.id}`}
+                  class="block bg-surface border border-surface-light rounded-lg p-5 card-glow group"
+                >
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0">
+                      <h3 class="font-mono text-sm font-bold text-text-bright group-hover:text-neon-green transition-colors">
+                        {entry.data.title}
+                      </h3>
+                      <p class="text-sm text-text-muted mt-1">{entry.data.summary}</p>
+                    </div>
+                    <time
+                      datetime={entry.data.date.toISOString()}
+                      class="font-mono text-xs text-text-muted shrink-0"
+                    >
+                      {entry.data.date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })}
+                    </time>
+                  </div>
+                  {entry.data.tags.length > 0 && (
+                    <div class="flex flex-wrap gap-1.5 mt-3">
+                      {entry.data.tags.map((t) => (
+                        <a
+                          href={`/tags/${t}`}
+                          class={`px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono transition-colors ${t === tag ? 'text-neon-cyan' : 'text-text-muted hover:text-neon-cyan'}`}
+                          onclick="event.stopPropagation()"
+                        >
+                          {t}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </a>
+              ))}
+          </div>
+        </section>
+      )}
+
+      {thoughtEntries.length > 0 && (
+        <section>
+          <h2 class="font-mono text-xs text-neon-cyan uppercase tracking-widest mb-4">Thoughts</h2>
+          <div class="grid gap-4">
+            {thoughtEntries
+              .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+              .map((entry) => (
+                <a
+                  href={`/thoughts/${entry.id}`}
+                  class="block bg-surface border border-surface-light rounded-lg p-5 card-glow group"
+                >
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0">
+                      <h3 class="font-mono text-sm font-bold text-text-bright group-hover:text-neon-cyan transition-colors">
+                        {entry.data.title}
+                      </h3>
+                      <p class="text-sm text-text-muted mt-1">{entry.data.summary}</p>
+                    </div>
+                    <time
+                      datetime={entry.data.date.toISOString()}
+                      class="font-mono text-xs text-text-muted shrink-0"
+                    >
+                      {entry.data.date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })}
+                    </time>
+                  </div>
+                  {entry.data.tags.length > 0 && (
+                    <div class="flex flex-wrap gap-1.5 mt-3">
+                      {entry.data.tags.map((t) => (
+                        <a
+                          href={`/tags/${t}`}
+                          class={`px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono transition-colors ${t === tag ? 'text-neon-cyan' : 'text-text-muted hover:text-neon-cyan'}`}
+                          onclick="event.stopPropagation()"
+                        >
+                          {t}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </a>
+              ))}
+          </div>
+        </section>
+      )}
+
+      {toolEntries.length > 0 && (
+        <section>
+          <h2 class="font-mono text-xs text-neon-purple uppercase tracking-widest mb-4">Tools & Experiments</h2>
+          <div class="grid gap-4">
+            {toolEntries.map((entry) => (
+              <a
+                href={`/tools/${entry.id}`}
+                class="block bg-surface border border-surface-light rounded-lg p-5 card-glow group"
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="min-w-0">
+                    <h3 class="font-mono text-sm font-bold text-text-bright group-hover:text-neon-purple transition-colors">
+                      {entry.data.title}
+                    </h3>
+                    <p class="text-sm text-text-muted mt-1">{entry.data.description}</p>
+                  </div>
+                  <span class={`shrink-0 px-2 py-0.5 rounded text-xs font-mono ${
+                    entry.data.status === 'active' ? 'bg-neon-green/10 text-neon-green' :
+                    entry.data.status === 'experimental' ? 'bg-neon-amber/10 text-neon-amber' :
+                    'bg-surface-light text-text-muted'
+                  }`}>
+                    {entry.data.status}
+                  </span>
+                </div>
+                {entry.data.tags.length > 0 && (
+                  <div class="flex flex-wrap gap-1.5 mt-3">
+                    {entry.data.tags.map((t) => (
+                      <a
+                        href={`/tags/${t}`}
+                        class={`px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono transition-colors ${t === tag ? 'text-neon-cyan' : 'text-text-muted hover:text-neon-cyan'}`}
+                        onclick="event.stopPropagation()"
+                      >
+                        {t}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const news = (await getCollection('news-and-updates')).filter((e) => !e.data.draft);
+const thoughts = (await getCollection('thoughts')).filter((e) => !e.data.draft);
+const tools = (await getCollection('tools')).filter((e) => !e.data.draft);
+
+const allEntries = [...news, ...thoughts, ...tools];
+
+const tagCounts = new Map<string, number>();
+for (const entry of allEntries) {
+  for (const tag of entry.data.tags) {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+}
+
+const tags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+---
+
+<BaseLayout title="Tags" description="Browse all content on SOFT CAT .ai by tag.">
+  <div class="max-w-3xl mx-auto px-6 py-16">
+    <header class="mb-12">
+      <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>
+      <h1 class="font-mono text-3xl font-bold text-text-bright glow-cyan">Tags</h1>
+      <p class="text-text-muted mt-2">Browse all content by tag. {tags.length} tags across {allEntries.length} posts.</p>
+    </header>
+
+    {tags.length === 0 ? (
+      <div class="bg-surface border border-surface-light rounded-lg p-8 text-center">
+        <p class="font-mono text-sm text-text-muted">
+          <span class="text-neon-cyan">&#9679;</span> no tags yet...
+        </p>
+      </div>
+    ) : (
+      <div class="flex flex-wrap gap-2">
+        {tags.map(([tag, count]) => (
+          <a
+            href={`/tags/${tag}`}
+            class="px-2.5 py-1 bg-surface border border-surface-light rounded font-mono text-sm text-text-muted hover:text-neon-cyan hover:border-neon-cyan/40 transition-colors"
+          >
+            {tag} <span class="text-text-muted/50">({count})</span>
+          </a>
+        ))}
+      </div>
+    )}
+  </div>
+</BaseLayout>

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -45,7 +45,13 @@ const entries = (await getCollection('thoughts'))
             {entry.data.tags.length > 0 && (
               <div class="flex flex-wrap gap-1.5 mt-3">
                 {entry.data.tags.map((tag) => (
-                  <span class="px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono text-text-muted">{tag}</span>
+                  <a
+                    href={`/tags/${tag}`}
+                    class="px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono text-text-muted hover:text-neon-cyan transition-colors"
+                    onclick="event.stopPropagation()"
+                  >
+                    {tag}
+                  </a>
                 ))}
               </div>
             )}

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -45,7 +45,13 @@ const entries = (await getCollection('tools'))
             {entry.data.tags.length > 0 && (
               <div class="flex flex-wrap gap-1.5 mt-3">
                 {entry.data.tags.map((tag) => (
-                  <span class="px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono text-text-muted">{tag}</span>
+                  <a
+                    href={`/tags/${tag}`}
+                    class="px-1.5 py-0.5 bg-surface-light rounded text-xs font-mono text-text-muted hover:text-neon-cyan transition-colors"
+                    onclick="event.stopPropagation()"
+                  >
+                    {tag}
+                  </a>
                 ))}
               </div>
             )}


### PR DESCRIPTION
Closes #1

## Changes
- `src/pages/tags/index.astro` (new) — lists all tags alphabetically with post counts, sorted by frequency
- `src/pages/tags/[tag].astro` (new) — dynamic page per tag showing matching news, thoughts, and tools entries grouped by section
- `src/pages/news-and-updates/index.astro` — tag chips now link to `/tags/[tag]`
- `src/pages/thoughts/index.astro` — tag chips now link to `/tags/[tag]`
- `src/pages/tools/index.astro` — tag chips now link to `/tags/[tag]`
- `src/components/Footer.astro` — added `tags` link in footer nav

## Verification
- Build passes: yes (99 pages built, 60 tag routes generated)
- Follows STYLE.md: yes

---
*Automated PR by SOFT CAT Builder*