### PR TITLE
auto: add JSON-LD Article and WebSite schema for LLM crawler visibility

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,6 +14,22 @@ const {
 } = Astro.props;
 
 const pageTitle = title === 'SOFT CAT .ai' ? title : `${title} | SOFT CAT .ai`;
+
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "SOFT CAT .ai",
+  "url": "https://softcat.ai",
+  "description": "Smart Outputs From Trained Conversational AI Technology. An AI site that maintains itself.",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://softcat.ai/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+};
 ---
 
 <!doctype html>
@@ -31,6 +47,8 @@ const pageTitle = title === 'SOFT CAT .ai' ? title : `${title} | SOFT CAT .ai`;
     />
     <link rel="alternate" type="application/rss+xml" title="SOFT CAT .ai" href="/feed.xml" />
     <title>{pageTitle}</title>
+    <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
+    <slot name="head" />
   </head>
   <body class="flex flex-col min-h-screen">
     <Header />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -12,9 +12,32 @@ interface Props {
 }
 
 const { title, date, tags = [], summary, backLink, backLabel } = Astro.props;
+
+const articleSchema: Record<string, unknown> = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": title,
+  "author": {
+    "@type": "Organization",
+    "name": "Valori"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "SOFT CAT .ai",
+    "url": "https://softcat.ai"
+  },
+  "url": Astro.url.href,
+};
+
+if (date) articleSchema["datePublished"] = date.toISOString();
+if (summary) articleSchema["description"] = summary;
+if (tags.length > 0) articleSchema["keywords"] = tags.join(", ");
 ---
 
 <BaseLayout title={title} description={summary}>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
+  </Fragment>
   <article class="max-w-3xl mx-auto px-6 py-16">
     <a
       href={backLink}


### PR DESCRIPTION
Closes #5

## Changes
- `src/layouts/BaseLayout.astro`: added `WebSite` JSON-LD schema with `SearchAction` stub in `<head>`; added `<slot name="head" />` so child layouts can inject additional head elements
- `src/layouts/PostLayout.astro`: added `Article` JSON-LD schema (headline, datePublished, author Valori, description, url, keywords) injected via `<Fragment slot="head">`

## Verification
- Build passes: yes (101 pages, 0 errors)
- Follows STYLE.md: yes

---
*Automated PR by SOFT CAT Builder*