### PR TITLE
auto: add prompt library homepage preview and amber accent

### DIFF
--- a/src/components/SectionPreview.astro
+++ b/src/components/SectionPreview.astro
@@ -14,7 +14,7 @@ interface Entry {
 
 interface Props {
   title: string;
-  accent: 'green' | 'cyan' | 'purple';
+  accent: 'green' | 'cyan' | 'purple' | 'amber';
   href: string;
   entries: Entry[];
   basePath: string;
@@ -49,6 +49,15 @@ const accentColors = {
     borderLeft: 'border-l-neon-purple/40',
     tagDot: 'tag-dot-purple',
     link: 'hover:text-neon-purple hover:border-neon-purple/30',
+  },
+  amber: {
+    dot: 'text-neon-amber',
+    title: 'text-neon-amber',
+    titleHover: 'group-hover:text-neon-amber',
+    cardGlow: 'card-glow-amber',
+    borderLeft: 'border-l-neon-amber/40',
+    tagDot: 'tag-dot-amber',
+    link: 'hover:text-neon-amber hover:border-neon-amber/30',
   },
 };
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,6 +22,11 @@ const thoughtEntries = allThoughts.filter((e) => !e.data.pinned).slice(0, 3);
 const toolEntries = (await getCollection('tools'))
   .filter((e) => !e.data.draft)
   .slice(0, 3);
+
+const promptEntries = (await getCollection('prompts'))
+  .filter((e) => !e.data.draft)
+  .sort((a, b) => a.data.title.localeCompare(b.data.title))
+  .slice(0, 3);
 ---
 
 <BaseLayout>
@@ -61,6 +66,16 @@ const toolEntries = (await getCollection('tools'))
       href="/tools"
       basePath="/tools"
       entries={toolEntries}
+    />
+  </div>
+
+  <div class="border-t border-surface-light/30">
+    <SectionPreview
+      title="Prompt Library"
+      accent="amber"
+      href="/prompts"
+      basePath="/prompts"
+      entries={promptEntries}
     />
   </div>
 


### PR DESCRIPTION
Closes #9

## Changes
- Added amber accent support to `SectionPreview` component (new `'amber'` option alongside green/cyan/purple)
- Added Prompt Library preview section to homepage (`/`), consistent with how news, thoughts, and tools sections are previewed
- The prompt library itself (`/prompts`, `/prompts/[slug]`) and all 8 seed entries were added in commit `3d54392`

## Verification
- Build passes: yes
- Follows STYLE.md: yes

---
*Automated PR by SOFT CAT Builder*