### PR TITLE
auto: add Giscus comment threads to /thoughts posts

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -9,9 +9,10 @@ interface Props {
   summary?: string;
   backLink: string;
   backLabel: string;
+  showComments?: boolean;
 }
 
-const { title, date, tags = [], summary, backLink, backLabel } = Astro.props;
+const { title, date, tags = [], summary, backLink, backLabel, showComments = false } = Astro.props;
 
 const articleSchema: Record<string, unknown> = {
   "@context": "https://schema.org",
@@ -78,5 +79,38 @@ if (tags.length > 0) articleSchema["keywords"] = tags.join(", ");
     <div class="prose text-text-primary">
       <slot />
     </div>
+
+    {showComments && (
+      <section class="mt-16 pt-10 border-t border-surface-light">
+        <h2 class="font-mono text-lg font-bold text-text-bright mb-6 glow-cyan">Discussion</h2>
+        <script
+          src="https://giscus.app/client.js"
+          data-repo="valorifutures/softcat.ai"
+          data-repo-id="R_kgDORXqv_Q"
+          data-category="Announcements"
+          data-category-id="DIC_kwDORXqv_c4C3iEm"
+          data-mapping="pathname"
+          data-strict="0"
+          data-reactions-enabled="1"
+          data-emit-metadata="0"
+          data-input-position="bottom"
+          data-theme="dark_tritanopia"
+          data-lang="en"
+          crossorigin="anonymous"
+          async
+        ></script>
+        <noscript>
+          <p class="text-text-muted font-mono text-sm">
+            Comments require JavaScript.
+            <a
+              href="https://github.com/valorifutures/softcat.ai/discussions"
+              class="text-neon-cyan hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >Join the discussion on GitHub.</a>
+          </p>
+        </noscript>
+      </section>
+    )}
   </article>
 </BaseLayout>

--- a/src/pages/thoughts/[...slug].astro
+++ b/src/pages/thoughts/[...slug].astro
@@ -21,6 +21,7 @@ const { Content } = await render(entry);
   summary={entry.data.summary}
   backLink="/thoughts"
   backLabel="Thoughts"
+  showComments={true}
 >
   <Content />
 </PostLayout>


### PR DESCRIPTION
Closes #11

## Changes
- Enabled GitHub Discussions on the repo (Announcements, General, Ideas, Polls, Q&A, Show and tell categories now available)
- Added `showComments?: boolean` prop to `src/layouts/PostLayout.astro`
- Added Giscus comment section below post body when `showComments` is true, using: repo `valorifutures/softcat.ai`, pathname mapping, Announcements category, `dark_tritanopia` theme
- Added `<noscript>` fallback linking to the GitHub Discussions tab
- Passed `showComments={true}` from `src/pages/thoughts/[...slug].astro`
- News & Updates posts are unaffected (no `showComments` prop passed)

## Verification
- Build passes: yes (149 pages built, 0 errors)
- Follows STYLE.md: yes (British English, font-mono heading, no em dashes)

---
*Automated PR by SOFT CAT Builder*