### PR TITLE
fix: replace RSS and status links in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,8 +9,8 @@ const year = new Date().getFullYear();
       <span class="flex items-center gap-3 text-xs">
         <a href="/glossary" class="hover:text-neon-purple transition-colors">glossary</a>
         <a href="/tags" class="hover:text-neon-cyan transition-colors">tags</a>
-        <a href="/feed.xml" class="hover:text-neon-amber transition-colors" title="RSS Feed">RSS</a>
-        <a href="/status" class="hover:text-neon-green transition-colors"><span class="text-neon-green">&#9679;</span> systems nominal</a>
+        <a href="/privacy" class="hover:text-neon-amber transition-colors">privacy</a>
+        <a href="/contact" class="hover:text-neon-green transition-colors">contact</a>
       </span>
     </div>
     <div class="font-mono text-xs text-text-muted/60">


### PR DESCRIPTION
## Summary
- Removes `/feed.xml` (RSS) and `/status` (systems nominal) links from footer to avoid exposing infrastructure details
- Replaces with `privacy` and `contact` links (pages to be created as follow-up)
- Build passes: 160 pages, 0 errors

## Follow-up
- Create `/privacy` page
- Create `/contact` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)