### PR TITLE
fix: add missing frontmatter delimiter to prompt file

### DIFF
--- a/src/content/prompts/production-monitoring-strategy-designer.md
+++ b/src/content/prompts/production-monitoring-strategy-designer.md
@@ -1,3 +1,4 @@
+---
 title: "Production Monitoring Strategy Designer"
 description: "Creates comprehensive monitoring and observability strategies for AI systems in production."
 category: "monitoring"


### PR DESCRIPTION
## Summary
- The radar bot pushed `production-monitoring-strategy-designer.md` without the opening `---` frontmatter delimiter
- This caused the Astro build to fail with `InvalidContentEntryDataError` (missing title, description, category, prompt)
- Adds the missing `---` to fix the build

## Test plan
- [x] `npm run build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)