### PR TITLE
auto: add WebSite/Organization JSON-LD schema and BreadcrumbList

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,11 +6,13 @@ import '../styles/global.css';
 interface Props {
   title?: string;
   description?: string;
+  breadcrumbs?: Array<{name: string, url: string}>;
 }
 
 const {
   title = 'SOFT CAT .ai',
   description = 'Smart Outputs From Trained Conversational AI Technology. An AI site that maintains itself.',
+  breadcrumbs,
 } = Astro.props;
 
 const pageTitle = title === 'SOFT CAT .ai' ? title : `${title} | SOFT CAT .ai`;
@@ -20,16 +22,27 @@ const websiteSchema = {
   "@type": "WebSite",
   "name": "SOFT CAT .ai",
   "url": "https://softcat.ai",
-  "description": "Smart Outputs From Trained Conversational AI Technology. An AI site that maintains itself.",
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": {
-      "@type": "EntryPoint",
-      "urlTemplate": "https://softcat.ai/search?q={search_term_string}"
-    },
-    "query-input": "required name=search_term_string"
+  "description": "Where trained AI becomes useful output.",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Valori",
+    "url": "https://softcat.ai"
   }
 };
+
+const breadcrumbSchema = breadcrumbs && breadcrumbs.length > 0 ? {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://softcat.ai"},
+    ...breadcrumbs.map((crumb, i) => ({
+      "@type": "ListItem",
+      "position": i + 2,
+      "name": crumb.name,
+      "item": `https://softcat.ai${crumb.url}`
+    }))
+  ]
+} : null;
 ---
 
 <!doctype html>
@@ -48,6 +61,9 @@ const websiteSchema = {
     <link rel="alternate" type="application/rss+xml" title="SOFT CAT .ai" href="/feed.xml" />
     <title>{pageTitle}</title>
     <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
+    {breadcrumbSchema && (
+      <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
+    )}
     <slot name="head" />
   </head>
   <body class="flex flex-col min-h-screen">

--- a/src/pages/lab/index.astro
+++ b/src/pages/lab/index.astro
@@ -61,7 +61,7 @@ const tools = [
 ];
 ---
 
-<BaseLayout title="Lab" description="Interactive AI tools built by SOFT CAT.">
+<BaseLayout title="Lab" description="Interactive AI tools built by SOFT CAT." breadcrumbs={[{name: 'Lab', url: '/lab'}]}>
   <div class="max-w-5xl mx-auto px-6 py-16">
     <header class="mb-8">
       <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>

--- a/src/pages/news-and-updates/index.astro
+++ b/src/pages/news-and-updates/index.astro
@@ -8,7 +8,7 @@ const entries = (await getCollection('news-and-updates'))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 ---
 
-<BaseLayout title="News & Updates" description="AI news, digests, and updates from the SOFT CAT pipeline.">
+<BaseLayout title="News & Updates" description="AI news, digests, and updates from the SOFT CAT pipeline." breadcrumbs={[{name: 'News & Updates', url: '/news-and-updates'}]}>
   <div class="max-w-4xl mx-auto px-6 py-16">
     <header class="mb-8">
       <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -8,7 +8,7 @@ const entries = (await getCollection('thoughts'))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 ---
 
-<BaseLayout title="Thoughts" description="Observations, opinions, and hot takes on AI developments.">
+<BaseLayout title="Thoughts" description="Observations, opinions, and hot takes on AI developments." breadcrumbs={[{name: 'Thoughts', url: '/thoughts'}]}>
   <div class="max-w-4xl mx-auto px-6 py-16">
     <header class="mb-8">
       <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -7,7 +7,7 @@ const entries = (await getCollection('tools'))
   .filter((e) => !e.data.draft);
 ---
 
-<BaseLayout title="Tools & Experiments" description="Micro-tools, AI finds, and experiments.">
+<BaseLayout title="Tools & Experiments" description="Micro-tools, AI finds, and experiments." breadcrumbs={[{name: 'Tools & Experiments', url: '/tools'}]}>
   <div class="max-w-4xl mx-auto px-6 py-16">
     <header class="mb-8">
       <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>


### PR DESCRIPTION
Closes #12

## Changes
- Updated `websiteSchema` in `BaseLayout.astro` to include `Organization` publisher (name: Valori, url: softcat.ai) and updated description to "Where trained AI becomes useful output."
- Removed the unused `potentialAction` SearchAction (no `/search` page exists)
- Added `breadcrumbs` prop to `BaseLayout.astro`; when provided, renders a `BreadcrumbList` JSON-LD block in `<head>` with Home as position 1
- Passed `breadcrumbs` from `/news-and-updates`, `/thoughts`, `/tools`, and `/lab` index pages

## Verification
- Build passes: yes (`npm run build` exits 0, 167 pages built)
- Follows STYLE.md: yes

---
*Automated PR by SOFT CAT Builder*