### PR TITLE
Permanent accent colours on hero nav links

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -45,28 +45,28 @@
     </a>
     <a
       href="/thoughts"
-      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-surface-light rounded-lg font-mono text-sm text-text-muted hover:text-neon-cyan hover:border-neon-cyan/30 transition-all"
+      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-neon-cyan/30 rounded-lg font-mono text-sm text-neon-cyan hover:bg-neon-cyan/10 hover:border-neon-cyan/60 transition-all"
     >
       <span>&gt;</span>
       <span>thoughts</span>
     </a>
     <a
       href="/radar"
-      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-surface-light rounded-lg font-mono text-sm text-text-muted hover:text-neon-red hover:border-neon-red/30 transition-all"
+      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-neon-red/30 rounded-lg font-mono text-sm text-neon-red hover:bg-neon-red/10 hover:border-neon-red/60 transition-all"
     >
       <span>&gt;</span>
       <span>the radar</span>
     </a>
     <a
       href="/prompts"
-      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-surface-light rounded-lg font-mono text-sm text-text-muted hover:text-neon-amber hover:border-neon-amber/30 transition-all"
+      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-neon-amber/30 rounded-lg font-mono text-sm text-neon-amber hover:bg-neon-amber/10 hover:border-neon-amber/60 transition-all"
     >
       <span>&gt;</span>
       <span>prompts</span>
     </a>
     <a
       href="/tools"
-      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-surface-light rounded-lg font-mono text-sm text-text-muted hover:text-neon-purple hover:border-neon-purple/30 transition-all"
+      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-neon-purple/30 rounded-lg font-mono text-sm text-neon-purple hover:bg-neon-purple/10 hover:border-neon-purple/60 transition-all"
     >
       <span>&gt;</span>
       <span>tools</span>


### PR DESCRIPTION
## Summary
- Hero nav links now show their section accent colour permanently, not just on hover
- Matches the existing News link pattern: coloured text + tinted border + bg glow on hover
- Thoughts (cyan), Radar (red), Prompts (amber), Tools (purple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)