### PR TITLE
feat: add Open Graph and Twitter Card meta tags

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,12 +7,14 @@ interface Props {
   title?: string;
   description?: string;
   breadcrumbs?: Array<{name: string, url: string}>;
+  type?: string;
 }
 
 const {
   title = 'SOFT CAT .ai',
   description = 'Smart Outputs From Trained Conversational AI Technology. An AI site that maintains itself.',
   breadcrumbs,
+  type = 'website',
 } = Astro.props;
 
 const pageTitle = title === 'SOFT CAT .ai' ? title : `${title} | SOFT CAT .ai`;
@@ -51,6 +53,14 @@ const breadcrumbSchema = breadcrumbs && breadcrumbs.length > 0 ? {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content={type} />
+    <meta property="og:url" content={`https://softcat.ai${Astro.url.pathname}`} />
+    <meta property="og:site_name" content="SOFT CAT .ai" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -35,7 +35,7 @@ if (summary) articleSchema["description"] = summary;
 if (tags.length > 0) articleSchema["keywords"] = tags.join(", ");
 ---
 
-<BaseLayout title={title} description={summary}>
+<BaseLayout title={title} description={summary} type="article">
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   </Fragment>


### PR DESCRIPTION
Closes #14

## Summary
- Added `og:title`, `og:description`, `og:type`, `og:url`, `og:site_name` meta tags to BaseLayout
- Added `twitter:card`, `twitter:title`, `twitter:description` meta tags
- Added `type` prop to BaseLayout (defaults to `website`), PostLayout passes `article`

## Test plan
- [x] `npm run build` passes (177 pages)
- [ ] Verify OG tags in built HTML output
- [ ] Test link preview on Discord/Twitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)