### PR TITLE
feat: add estimated reading time to posts

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -10,9 +10,10 @@ interface Props {
   backLink: string;
   backLabel: string;
   showComments?: boolean;
+  readingTime?: number;
 }
 
-const { title, date, tags = [], summary, backLink, backLabel, showComments = false } = Astro.props;
+const { title, date, tags = [], summary, backLink, backLabel, showComments = false, readingTime } = Astro.props;
 
 const articleSchema: Record<string, unknown> = {
   "@context": "https://schema.org",
@@ -58,6 +59,9 @@ if (tags.length > 0) articleSchema["keywords"] = tags.join(", ");
           <time datetime={date.toISOString()} class="font-mono">
             {date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
           </time>
+        )}
+        {readingTime && (
+          <span class="font-mono">&middot; {readingTime} min read</span>
         )}
         {tags.length > 0 && (
           <div class="flex flex-wrap gap-2">

--- a/src/pages/news-and-updates/[...slug].astro
+++ b/src/pages/news-and-updates/[...slug].astro
@@ -12,6 +12,8 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
+const words = entry.body?.trim().split(/\s+/).length ?? 0;
+const readingTime = Math.max(1, Math.ceil(words / 200));
 ---
 
 <PostLayout
@@ -21,6 +23,7 @@ const { Content } = await render(entry);
   summary={entry.data.summary}
   backLink="/news-and-updates"
   backLabel="News & Updates"
+  readingTime={readingTime}
 >
   <Content />
 </PostLayout>

--- a/src/pages/thoughts/[...slug].astro
+++ b/src/pages/thoughts/[...slug].astro
@@ -12,6 +12,8 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
+const words = entry.body?.trim().split(/\s+/).length ?? 0;
+const readingTime = Math.max(1, Math.ceil(words / 200));
 ---
 
 <PostLayout
@@ -22,6 +24,7 @@ const { Content } = await render(entry);
   backLink="/thoughts"
   backLabel="Thoughts"
   showComments={true}
+  readingTime={readingTime}
 >
   <Content />
 </PostLayout>


### PR DESCRIPTION
Closes #17

## Summary
- Added `readingTime` prop to PostLayout, displayed as "· X min read" after the date
- Computed at build time from `entry.body` (200 wpm, rounded up, minimum 1 min)
- Applied to both news-and-updates and thoughts post pages

## Test plan
- [x] `npm run build` passes (177 pages)
- [ ] Verify reading time appears on post pages
- [ ] Check short posts show "1 min read"

🤖 Generated with [Claude Code](https://claude.com/claude-code)