### PR TITLE
style: dark premium theme — desaturated palette, refined glows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Site Is
 
-SOFT CAT .ai (softcat.ai) is a neon cyberpunk AI site built with Astro 5.17 + Preact + Tailwind 4.2.
+SOFT CAT .ai (softcat.ai) is a dark premium AI site built with Astro 5.17 + Preact + Tailwind 4.2.
 It deploys via GitHub Actions to GitHub Pages on every push to `main`.
 The domain is softcat.ai. The GitHub repo is valorifutures/softcat.ai.
 
@@ -18,7 +18,7 @@ The domain is softcat.ai. The GitHub repo is valorifutures/softcat.ai.
 - **Framework**: Astro 5.17 (static site generator)
 - **UI**: Preact components (`.tsx`) for interactive bits, Astro components (`.astro`) for everything else
 - **Styling**: Tailwind CSS 4.2 via Vite plugin. Theme defined in `src/styles/global.css`.
-- **Colors**: void (#0a0a0f), surface (#12121a), surface-light (#1a1a2e), neon-green (#00ff9f), neon-cyan (#00d4ff), neon-purple (#b44aff), neon-amber (#ffb800)
+- **Colors**: void (#0c0c14), surface (#14141e), surface-light (#1e1e30), neon-green (#4ecb8f), neon-cyan (#5ab8d4), neon-purple (#9b7acc), neon-amber (#d4a54a), neon-red (#da5e74)
 - **Fonts**: Inter (sans), JetBrains Mono (mono). Mono used for headings and UI elements.
 - **Build**: `npm run build` outputs to `dist/`. Must pass before any PR.
 

--- a/src/components/SearchOverlay.tsx
+++ b/src/components/SearchOverlay.tsx
@@ -9,13 +9,13 @@ interface SearchEntry {
   date?: string;
 }
 
-const TYPE_META: Record<string, { label: string; color: string }> = {
-  news: { label: 'news', color: '#00ff9f' },
-  thought: { label: 'thought', color: '#00d4ff' },
-  tool: { label: 'tool', color: '#b44aff' },
-  prompt: { label: 'prompt', color: '#ffb800' },
-  radar: { label: 'radar', color: '#ff3366' },
-  page: { label: 'page', color: '#adadc4' },
+const TYPE_META: Record<string, { label: string; text: string; border: string; bg: string }> = {
+  news: { label: 'news', text: 'text-neon-green', border: 'border-neon-green/25', bg: 'bg-neon-green/10' },
+  thought: { label: 'thought', text: 'text-neon-cyan', border: 'border-neon-cyan/25', bg: 'bg-neon-cyan/10' },
+  tool: { label: 'tool', text: 'text-neon-purple', border: 'border-neon-purple/25', bg: 'bg-neon-purple/10' },
+  prompt: { label: 'prompt', text: 'text-neon-amber', border: 'border-neon-amber/25', bg: 'bg-neon-amber/10' },
+  radar: { label: 'radar', text: 'text-neon-red', border: 'border-neon-red/25', bg: 'bg-neon-red/10' },
+  page: { label: 'page', text: 'text-text-muted', border: 'border-text-muted/25', bg: 'bg-text-muted/10' },
 };
 
 function fuzzyMatch(query: string, text: string): number {
@@ -151,7 +151,7 @@ export default function SearchOverlay() {
 
       {/* Modal */}
       <div class="relative w-full max-w-xl mx-4 rounded-xl border border-surface-light/50 bg-surface shadow-2xl overflow-hidden"
-        style="box-shadow: 0 0 60px rgba(0, 255, 159, 0.06), 0 25px 50px rgba(0, 0, 0, 0.5)"
+        style="box-shadow: 0 0 30px rgba(78, 203, 143, 0.04), 0 25px 50px rgba(0, 0, 0, 0.5)"
       >
         {/* Input */}
         <div class="flex items-center gap-3 px-4 py-3 border-b border-surface-light/50">
@@ -203,13 +203,7 @@ export default function SearchOverlay() {
                   }`}
                 >
                   <span
-                    class="shrink-0 mt-0.5 text-[10px] px-1.5 py-0.5 rounded-full border"
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      color: meta.color,
-                      borderColor: meta.color + '40',
-                      backgroundColor: meta.color + '10',
-                    }}
+                    class={`shrink-0 mt-0.5 text-[10px] font-mono px-1.5 py-0.5 rounded-full border ${meta.text} ${meta.border} ${meta.bg}`}
                   >
                     {meta.label}
                   </span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,16 +2,16 @@
 
 @theme {
   /* Background layers */
-  --color-void: #0a0a0f;
-  --color-surface: #12121a;
-  --color-surface-light: #1a1a2e;
+  --color-void: #0c0c14;
+  --color-surface: #14141e;
+  --color-surface-light: #1e1e30;
 
-  /* Neon accents */
-  --color-neon-green: #00ff9f;
-  --color-neon-cyan: #00d4ff;
-  --color-neon-purple: #b44aff;
-  --color-neon-amber: #ffb800;
-  --color-neon-red: #ff3366;
+  /* Neon accents — desaturated premium palette */
+  --color-neon-green: #4ecb8f;
+  --color-neon-cyan: #5ab8d4;
+  --color-neon-purple: #9b7acc;
+  --color-neon-amber: #d4a54a;
+  --color-neon-red: #da5e74;
 
   /* Text */
   --color-text-primary: #ededf2;
@@ -29,31 +29,31 @@ body {
   color: var(--color-text-primary);
   font-family: var(--font-sans);
   background-image:
-    linear-gradient(rgba(0, 255, 159, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 255, 159, 0.03) 1px, transparent 1px);
+    linear-gradient(rgba(78, 203, 143, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(78, 203, 143, 0.02) 1px, transparent 1px);
   background-size: 50px 50px;
   min-height: 100vh;
 }
 
-/* Glow utilities */
+/* Glow utilities — single layer, refined */
 .glow-green {
-  text-shadow: 0 0 10px rgba(0, 255, 159, 0.5), 0 0 20px rgba(0, 255, 159, 0.2);
+  text-shadow: 0 0 8px rgba(78, 203, 143, 0.4);
 }
 
 .glow-cyan {
-  text-shadow: 0 0 10px rgba(0, 212, 255, 0.5), 0 0 20px rgba(0, 212, 255, 0.2);
+  text-shadow: 0 0 8px rgba(90, 184, 212, 0.4);
 }
 
 .glow-purple {
-  text-shadow: 0 0 10px rgba(180, 74, 255, 0.5), 0 0 20px rgba(180, 74, 255, 0.2);
+  text-shadow: 0 0 8px rgba(155, 122, 204, 0.4);
 }
 
 .glow-amber {
-  text-shadow: 0 0 10px rgba(255, 184, 0, 0.5), 0 0 20px rgba(255, 184, 0, 0.2);
+  text-shadow: 0 0 8px rgba(212, 165, 74, 0.4);
 }
 
 .glow-red {
-  text-shadow: 0 0 10px rgba(255, 51, 102, 0.5), 0 0 20px rgba(255, 51, 102, 0.2);
+  text-shadow: 0 0 8px rgba(218, 94, 116, 0.4);
 }
 
 /* Card base transition */
@@ -62,50 +62,50 @@ body {
 }
 
 .card-glow:hover {
-  border-color: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 0 15px rgba(255, 255, 255, 0.02);
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.02);
 }
 
-/* Section-specific card glow */
+/* Section-specific card glow — refined, single shadow */
 .card-glow-green:hover {
-  border-color: rgba(0, 255, 159, 0.35);
-  box-shadow: 0 0 20px rgba(0, 255, 159, 0.1), 0 0 60px rgba(0, 255, 159, 0.04), inset 0 1px 0 rgba(0, 255, 159, 0.06);
+  border-color: rgba(78, 203, 143, 0.3);
+  box-shadow: 0 0 12px rgba(78, 203, 143, 0.08);
 }
 
 .card-glow-cyan:hover {
-  border-color: rgba(0, 212, 255, 0.35);
-  box-shadow: 0 0 20px rgba(0, 212, 255, 0.1), 0 0 60px rgba(0, 212, 255, 0.04), inset 0 1px 0 rgba(0, 212, 255, 0.06);
+  border-color: rgba(90, 184, 212, 0.3);
+  box-shadow: 0 0 12px rgba(90, 184, 212, 0.08);
 }
 
 .card-glow-purple:hover {
-  border-color: rgba(180, 74, 255, 0.35);
-  box-shadow: 0 0 20px rgba(180, 74, 255, 0.1), 0 0 60px rgba(180, 74, 255, 0.04), inset 0 1px 0 rgba(180, 74, 255, 0.06);
+  border-color: rgba(155, 122, 204, 0.3);
+  box-shadow: 0 0 12px rgba(155, 122, 204, 0.08);
 }
 
 .card-glow-amber:hover {
-  border-color: rgba(255, 184, 0, 0.35);
-  box-shadow: 0 0 20px rgba(255, 184, 0, 0.1), 0 0 60px rgba(255, 184, 0, 0.04), inset 0 1px 0 rgba(255, 184, 0, 0.06);
+  border-color: rgba(212, 165, 74, 0.3);
+  box-shadow: 0 0 12px rgba(212, 165, 74, 0.08);
 }
 
 .card-glow-red:hover {
-  border-color: rgba(255, 51, 102, 0.35);
-  box-shadow: 0 0 20px rgba(255, 51, 102, 0.1), 0 0 60px rgba(255, 51, 102, 0.04), inset 0 1px 0 rgba(255, 51, 102, 0.06);
+  border-color: rgba(218, 94, 116, 0.3);
+  box-shadow: 0 0 12px rgba(218, 94, 116, 0.08);
 }
 
 /* Glassmorphism card */
 .glass-card {
   background: linear-gradient(
     135deg,
-    rgba(18, 18, 26, 0.85) 0%,
-    rgba(26, 26, 46, 0.7) 50%,
-    rgba(18, 18, 26, 0.85) 100%
+    rgba(20, 20, 30, 0.85) 0%,
+    rgba(30, 30, 48, 0.7) 50%,
+    rgba(20, 20, 30, 0.85) 100%
   );
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-/* Top edge shimmer */
+/* Top edge highlight — static, no shimmer */
 .glass-card::before {
   content: '';
   position: absolute;
@@ -116,9 +116,9 @@ body {
   background: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(255, 255, 255, 0.12) 30%,
-    rgba(255, 255, 255, 0.15) 50%,
-    rgba(255, 255, 255, 0.12) 70%,
+    rgba(255, 255, 255, 0.06) 30%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.06) 70%,
     transparent 100%
   );
   border-radius: inherit;
@@ -144,11 +144,11 @@ body {
 }
 
 /* Section accent lines */
-.card-glow-green { --card-accent: rgba(0, 255, 159, 0.3); }
-.card-glow-cyan { --card-accent: rgba(0, 212, 255, 0.3); }
-.card-glow-purple { --card-accent: rgba(180, 74, 255, 0.3); }
-.card-glow-amber { --card-accent: rgba(255, 184, 0, 0.3); }
-.card-glow-red { --card-accent: rgba(255, 51, 102, 0.3); }
+.card-glow-green { --card-accent: rgba(78, 203, 143, 0.25); }
+.card-glow-cyan { --card-accent: rgba(90, 184, 212, 0.25); }
+.card-glow-purple { --card-accent: rgba(155, 122, 204, 0.25); }
+.card-glow-amber { --card-accent: rgba(212, 165, 74, 0.25); }
+.card-glow-red { --card-accent: rgba(218, 94, 116, 0.25); }
 
 /* Ambient glow orb — place behind card grids */
 .ambient-glow {
@@ -163,7 +163,7 @@ body {
   width: 300px;
   height: 300px;
   border-radius: 50%;
-  background: var(--glow-color, rgba(0, 255, 159, 0.03));
+  background: var(--glow-color, rgba(78, 203, 143, 0.02));
   filter: blur(100px);
   pointer-events: none;
   z-index: 0;
@@ -177,7 +177,7 @@ body {
   width: 250px;
   height: 250px;
   border-radius: 50%;
-  background: var(--glow-color-alt, rgba(180, 74, 255, 0.025));
+  background: var(--glow-color-alt, rgba(155, 122, 204, 0.015));
   filter: blur(80px);
   pointer-events: none;
   z-index: 0;
@@ -293,8 +293,8 @@ body {
 
 .tag-badge:hover {
   color: var(--color-neon-cyan);
-  border-color: rgba(0, 212, 255, 0.2);
-  background: rgba(0, 212, 255, 0.05);
+  border-color: rgba(90, 184, 212, 0.2);
+  background: rgba(90, 184, 212, 0.05);
 }
 
 .tag-dot {
@@ -374,7 +374,7 @@ body {
 .prose a {
   color: var(--color-neon-cyan);
   text-decoration: underline;
-  text-decoration-color: rgba(0, 212, 255, 0.3);
+  text-decoration-color: rgba(90, 184, 212, 0.3);
   text-underline-offset: 3px;
   transition: text-decoration-color 0.2s;
 }


### PR DESCRIPTION
## Summary
- Evolve colour palette from neon arcade to desaturated premium: green #4ecb8f, cyan #5ab8d4, purple #9b7acc, amber #d4a54a, red #da5e74
- All 5 accent colours pass WCAG AA (4.5:1) contrast ratio on all background surfaces
- Reduce glow effects to single-layer text-shadows (was dual-layer)
- Tighten card hover effects: 12px blur at 0.08 opacity (was 20-60px multi-shadow)
- Dim glass-card top highlight and ambient glow orbs
- Refactor SearchOverlay from hardcoded hex values to Tailwind classes, eliminating colour duplication between CSS and JS
- Update CLAUDE.md colour documentation to match new palette

## Pre-Landing Review
Pre-Landing Review: No issues found (after splitting out 2 unrelated pre-existing changes).

## Test plan
- [x] Astro build passes (236 pages, 0 errors)
- [x] WCAG AA contrast ratios verified programmatically for all accent/background combinations
- [ ] Visual QA with /browse post-deploy (contrast on small text, tag badges, search overlay badges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)