### PR TITLE
fix: sync inline rgba colours with premium palette

### DIFF
--- a/src/pages/glossary.astro
+++ b/src/pages/glossary.astro
@@ -200,7 +200,7 @@ const glossarySchema = {
       <p class="text-text-muted mt-2">Plain-English definitions for the terms that keep coming up. {terms.length} entries, sorted alphabetically.</p>
     </header>
 
-    <div class="glow-divider mb-8" style="--divider-color: rgba(180, 74, 255, 0.15)"></div>
+    <div class="glow-divider mb-8" style="--divider-color: rgba(155, 122, 204, 0.15)"></div>
 
     <!-- Alphabet jump nav -->
     <nav class="flex flex-wrap gap-2 mb-10" aria-label="Jump to letter">
@@ -215,7 +215,7 @@ const glossarySchema = {
     </nav>
 
     <!-- Grouped term listings -->
-    <div class="space-y-12 ambient-glow" style="--glow-color: rgba(180, 74, 255, 0.035); --glow-color-alt: rgba(0, 212, 255, 0.025)">
+    <div class="space-y-12 ambient-glow" style="--glow-color: rgba(155, 122, 204, 0.035); --glow-color-alt: rgba(90, 184, 212, 0.025)">
       {letters.map((letter) => (
         <section id={`letter-${letter}`}>
           <h2 class="font-mono text-xl font-bold text-neon-purple glow-purple mb-4">{letter}</h2>

--- a/src/pages/news-and-updates/index.astro
+++ b/src/pages/news-and-updates/index.astro
@@ -16,7 +16,7 @@ const entries = (await getCollection('news-and-updates'))
       <p class="text-text-muted mt-2">AI news, digests, and updates from the SOFT CAT pipeline.</p>
     </header>
     <div class="section-banner mb-6" style="height: 180px; --banner-accent: rgba(78, 203, 143, 0.12); --banner-accent-mid: rgba(78, 203, 143, 0.04)" aria-hidden="true"></div>
-    <div class="glow-divider mb-10" style="--divider-color: rgba(0, 255, 159, 0.15)"></div>
+    <div class="glow-divider mb-10" style="--divider-color: rgba(78, 203, 143, 0.15)"></div>
 
     {entries.length === 0 ? (
       <div class="bg-surface border border-surface-light rounded-lg p-8 text-center">
@@ -25,7 +25,7 @@ const entries = (await getCollection('news-and-updates'))
         </p>
       </div>
     ) : (
-      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(0, 255, 159, 0.035); --glow-color-alt: rgba(0, 212, 255, 0.025)">
+      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(78, 203, 143, 0.035); --glow-color-alt: rgba(90, 184, 212, 0.025)">
         {entries.map((entry, index) => (
           <div
             class="relative glass-card rounded-xl card-glow card-glow-green card-lift group animate-stagger border-l-2 border-l-neon-green/40 overflow-hidden"

--- a/src/pages/prompts/[...slug].astro
+++ b/src/pages/prompts/[...slug].astro
@@ -39,7 +39,7 @@ const { Content } = await render(entry);
       )}
     </header>
 
-    <div class="glow-divider mb-8" style="--divider-color: rgba(255, 184, 0, 0.15)"></div>
+    <div class="glow-divider mb-8" style="--divider-color: rgba(212, 165, 74, 0.15)"></div>
 
     <!-- Prompt block -->
     <div class="relative mb-8">

--- a/src/pages/prompts/index.astro
+++ b/src/pages/prompts/index.astro
@@ -16,7 +16,7 @@ const entries = (await getCollection('prompts'))
       <p class="text-text-muted mt-2">Copy-ready prompts for common developer tasks.</p>
     </header>
     <div class="section-banner mb-6" style="height: 180px; --banner-accent: rgba(212, 165, 74, 0.12); --banner-accent-mid: rgba(212, 165, 74, 0.04)" aria-hidden="true"></div>
-    <div class="glow-divider mb-10" style="--divider-color: rgba(255, 184, 0, 0.15)"></div>
+    <div class="glow-divider mb-10" style="--divider-color: rgba(212, 165, 74, 0.15)"></div>
 
     {entries.length === 0 ? (
       <div class="bg-surface border border-surface-light rounded-lg p-8 text-center">
@@ -25,7 +25,7 @@ const entries = (await getCollection('prompts'))
         </p>
       </div>
     ) : (
-      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(255, 184, 0, 0.035); --glow-color-alt: rgba(0, 212, 255, 0.025)">
+      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(212, 165, 74, 0.035); --glow-color-alt: rgba(90, 184, 212, 0.025)">
         {entries.map((entry, index) => (
           <div
             class="relative glass-card rounded-xl card-glow card-glow-amber card-lift group animate-stagger border-l-2 border-l-neon-amber/40 overflow-hidden"

--- a/src/pages/radar/[date].astro
+++ b/src/pages/radar/[date].astro
@@ -35,7 +35,7 @@ const olderDate = dateIndex < manifest.dates.length - 1 ? manifest.dates[dateInd
       <p class="text-text-muted mt-2">{formatDate(date!)}</p>
     </header>
 
-    <div class="glow-divider mb-6" style="--divider-color: rgba(255, 51, 102, 0.15)"></div>
+    <div class="glow-divider mb-6" style="--divider-color: rgba(218, 94, 116, 0.15)"></div>
 
     <nav class="flex items-center justify-between mb-10">
       {olderDate ? (
@@ -75,7 +75,7 @@ const olderDate = dateIndex < manifest.dates.length - 1 ? manifest.dates[dateInd
         {dayData.featured.length > 0 && (
           <section class="mb-12">
             <h2 class="font-mono text-xs text-neon-red uppercase tracking-widest mb-6">Today's picks</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-5 ambient-glow" style="--glow-color: rgba(255, 51, 102, 0.035); --glow-color-alt: rgba(0, 212, 255, 0.025)">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5 ambient-glow" style="--glow-color: rgba(218, 94, 116, 0.035); --glow-color-alt: rgba(90, 184, 212, 0.025)">
               {dayData.featured.map((item: any, index: number) => (
                 <RadarFeaturedCard item={item} index={index} />
               ))}

--- a/src/pages/radar/index.astro
+++ b/src/pages/radar/index.astro
@@ -26,7 +26,7 @@ const olderDate = manifest.dates.length > 1 ? manifest.dates[1] : null;
       <p class="text-text-muted mt-2">AI tools, launches, and products worth knowing about. Curated daily by the SOFT CAT pipeline.</p>
     </header>
     <div class="section-banner mb-6" style="height: 180px; --banner-accent: rgba(218, 94, 116, 0.12); --banner-accent-mid: rgba(218, 94, 116, 0.04)" aria-hidden="true"></div>
-    <div class="glow-divider mb-6" style="--divider-color: rgba(255, 51, 102, 0.15)"></div>
+    <div class="glow-divider mb-6" style="--divider-color: rgba(218, 94, 116, 0.15)"></div>
 
     {olderDate && (
       <nav class="flex items-center justify-between mb-10">
@@ -62,7 +62,7 @@ const olderDate = manifest.dates.length > 1 ? manifest.dates[1] : null;
         {dayData.featured.length > 0 && (
           <section class="mb-12">
             <h2 class="font-mono text-xs text-neon-red uppercase tracking-widest mb-6">Today's picks</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-5 ambient-glow" style="--glow-color: rgba(255, 51, 102, 0.035); --glow-color-alt: rgba(0, 212, 255, 0.025)">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5 ambient-glow" style="--glow-color: rgba(218, 94, 116, 0.035); --glow-color-alt: rgba(90, 184, 212, 0.025)">
               {dayData.featured.map((item: any, index: number) => (
                 <RadarFeaturedCard item={item} index={index} />
               ))}

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -16,7 +16,7 @@ const entries = (await getCollection('thoughts'))
       <p class="text-text-muted mt-2">Observations, opinions, and hot takes on AI developments.</p>
     </header>
     <div class="section-banner mb-6" style="height: 180px; --banner-accent: rgba(90, 184, 212, 0.12); --banner-accent-mid: rgba(90, 184, 212, 0.04)" aria-hidden="true"></div>
-    <div class="glow-divider mb-10" style="--divider-color: rgba(0, 212, 255, 0.15)"></div>
+    <div class="glow-divider mb-10" style="--divider-color: rgba(90, 184, 212, 0.15)"></div>
 
     {entries.length === 0 ? (
       <div class="bg-surface border border-surface-light rounded-lg p-8 text-center">
@@ -25,7 +25,7 @@ const entries = (await getCollection('thoughts'))
         </p>
       </div>
     ) : (
-      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(0, 212, 255, 0.035); --glow-color-alt: rgba(180, 74, 255, 0.025)">
+      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(90, 184, 212, 0.035); --glow-color-alt: rgba(155, 122, 204, 0.025)">
         {entries.map((entry, index) => (
           <div
             class="relative glass-card rounded-xl card-glow card-glow-cyan card-lift group animate-stagger border-l-2 border-l-neon-cyan/40 overflow-hidden"

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -110,7 +110,7 @@ const labTools = [
     </div>
 
     <!-- Tool write-ups -->
-    <div class="glow-divider mb-8" style="--divider-color: rgba(180, 74, 255, 0.15)"></div>
+    <div class="glow-divider mb-8" style="--divider-color: rgba(155, 122, 204, 0.15)"></div>
     <h2 class="font-mono text-lg font-bold text-text-bright flex items-center gap-2 mb-5">
       <span class="text-neon-purple">&#9632;</span>
       Write-ups
@@ -123,7 +123,7 @@ const labTools = [
         </p>
       </div>
     ) : (
-      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(180, 74, 255, 0.035); --glow-color-alt: rgba(0, 212, 255, 0.025)">
+      <div class="grid gap-5 ambient-glow" style="--glow-color: rgba(155, 122, 204, 0.035); --glow-color-alt: rgba(90, 184, 212, 0.025)">
         {entries.map((entry, index) => (
           <div
             class="relative glass-card rounded-xl card-glow card-glow-purple card-lift group animate-stagger border-l-2 border-l-neon-purple/40 overflow-hidden"


### PR DESCRIPTION
## Summary
- Update 15 inline `rgba()` references across 8 page files to match the desaturated palette from PR #58
- Covers `glow-divider` and `ambient-glow` CSS variable overrides on all section pages, glossary, and dynamic routes
- Zero old neon colour references remain in the codebase

## Pre-Landing Review
No issues found. Pure colour value swap, no logic changes.

## Test plan
- [x] Astro build passes (236 pages, 0 errors)
- [x] Grep confirms zero remaining old neon rgba references

🤖 Generated with [Claude Code](https://claude.com/claude-code)