### PR TITLE
content: rewrite What is SOFT CAT to match pipeline

### DIFF
--- a/src/content/thoughts/2026-02-25-what-is-softcat.md
+++ b/src/content/thoughts/2026-02-25-what-is-softcat.md
@@ -1,98 +1,54 @@
 ---
 title: "What SOFT CAT is and why we built it"
-date: 2026-02-25
-tags: [softcat, agents, announcement]
-summary: "The mantra, the site, and the CLI that turns plain English into deployed AI agents."
+date: 2026-03-13
+tags: [softcat, agents, pipeline]
+summary: "softcat.ai builds and maintains itself via six AI bots. This is how."
 draft: false
 pinned: true
 ---
 
-SOFT CAT stands for **Smart Outputs From Trained Conversational AI Technology**. It's the principle behind everything we do here: use AI to produce useful, reliable outputs. Not demos, not experiments, but things that actually run.
+This morning, before anyone sat down at a keyboard, six bots ran on a home server in the UK. One pulled RSS feeds and wrote a news digest. Another read the same feeds and wrote an opinion piece. A third scanned for AI product launches and published editorial picks. The other three updated the model database, the prompt library, and the tool reviews.
 
-The name covers three things:
+You can see the results at [/pipeline](/pipeline).
 
-- **SOFT CAT** the idea. AI should produce smart outputs, autonomously, on a schedule, without babysitting.
-- **softcat.ai** the site. Where we document what we build, powered by its own AI agents.
-- **The softcat CLI**. A command line tool that turns plain English into deployed, scheduled, self-monitoring AI agents.
+That is what SOFT CAT is.
 
-This post is mostly about the CLI, because that's the part that makes the rest possible.
+## The name
 
-## The CLI
+SOFT CAT stands for **Smart Outputs From Trained Conversational AI Technology**. The principle is straightforward: use AI to produce useful, reliable outputs. Not demos, not experiments. Things that actually run, on a schedule, without supervision.
 
-The softcat CLI takes a plain English description of what you want an agent to do, builds it, tests it, deploys it on a schedule, and monitors it. The whole thing takes about two minutes.
+softcat.ai is the site where we build in public. It is also the thing being built. The content, the tools, the daily updates. Most of it comes from the bots, not from us.
 
-```
-softcat spawn "watch HackerNews for AI agent news, summarise the top 5 daily"
-```
+## The pipeline
 
-That one command runs a seven-stage pipeline, one for each letter in the name:
+Six bots run on a Beelink SER5 MAX on a home network. Each has a specific job.
 
-- **Scan** parses your description using Claude to extract intent, data sources, schedule, and output format
-- **Orchestrate** selects the right model, dependencies, and tools
-- **Fabricate** generates the agent code and prompt template in a single Claude call
-- **Test** runs syntax checks and a dry-run with mock data
-- **Configure** sets up cron scheduling and health monitoring
-- **Activate** creates an isolated virtual environment, installs dependencies, registers the cron job
-- **Track** wires up monitoring so you know when something breaks
+**AI News Digest** pulls five RSS feeds every morning, picks the most interesting stories, and writes an opinionated digest for [/news-and-updates](/news-and-updates). It runs daily at 07:00 UTC.
 
-The output is a self-contained directory with a Python script, prompt template, config file, and its own virtual environment. It runs on cron. It pings a health check on success. It writes its outputs to a local directory. No cloud platform, no containers, no YAML sprawl.
+**AI Thoughts** reads the same feeds for inspiration and generates an original opinion piece with a clear point of view. It publishes to [/thoughts](/thoughts) daily at 08:00 UTC.
 
-## Why agents fail in production
+**The Radar** scans RSS feeds and the HackerNews API for genuine AI product launches. It writes editorial picks for each and publishes them to [/radar](/radar) at 09:30 UTC. No human curates the picks.
 
-We've watched dozens of agent projects die the same way. The demo works. The prototype works. Then someone tries to run it every day and it falls apart.
+**Tool of the Week** picks one interesting AI tool from the feeds every Sunday and writes a short review for [/tools](/tools).
 
-The problems are always the same:
+**Prompt Library** generates copy-ready prompt templates twice a month, inspired by current AI trends. These go to [/prompts](/prompts).
 
-- **No isolation.** One agent's dependencies break another's.
-- **No scheduling.** Someone has to remember to run it, or hack together a cron job.
-- **No monitoring.** When it fails at 3am, nobody knows until someone asks "where's that report?"
-- **No testing.** The code was generated once and never validated.
-- **No update path.** When the framework changes, you rewrite from scratch.
+**Model Data** fetches AI model pricing and specs from the OpenRouter API every morning and updates the models comparison page. No language model involved. Just an API call and a JSON file.
 
-The softcat CLI handles all of these by default. Each agent gets its own virtual environment. Scheduling is automatic. Health checks are built in. The tester validates both syntax and runtime behaviour. And `softcat groom` regenerates the code while keeping your config and outputs intact.
+All six bots use Claude Sonnet for generation (except Model Data, which is pure API). Every run is logged: duration, feeds scanned, items found, items published, cost. The pipeline dashboard at [/pipeline](/pipeline) shows all of it.
 
-## How we actually use it
+## What is still rough
 
-This site runs on agents built with the CLI. The AI news digests that appear in our news section are written by an agent that checks HackerNews every morning, filters for AI-related stories, and generates a summary with Claude. The tool reviews come from an agent monitoring Product Hunt for developer tools.
+The bots do not decide what matters. They surface what is new, but they do not know what the site should prioritise. Those calls still belong to humans.
 
-We didn't write those agents by hand. We described what we wanted and the CLI built them.
+The pipeline dashboard shows every run, its cost, and its output. Some days a bot runs and produces nothing useful. Some days the same story appears in both the digest and the radar. We keep the history visible because that is more honest than only showing the wins.
 
-When we need to iterate, we use `softcat meow` for a conversational design session where Claude asks questions to understand exactly what we need. When we want to update an agent's code without losing its configuration, `softcat groom` regenerates it. When we want to test something right now, `softcat trigger` runs it immediately.
+There is no "Scout" filing issues or "Builder" writing code. The bots generate content. We review it, maintain the infrastructure, and decide what to build next. That is the only manual step.
 
-The full command set follows the cat theme:
+## The point
 
-- `spawn` creates an agent
-- `meow` designs one through conversation
-- `litter` lists them all
-- `purr` checks status
-- `feed` shows recent outputs
-- `trigger` runs one immediately
-- `nap` and `wake` pause and resume
-- `groom` regenerates code
-- `hiss` kills one permanently
+This is not a pitch for a product. What exists is the infrastructure running this site: six bots, a home server, a GitHub repo, and a cron schedule.
 
-## What's under the hood
+The interesting question is not whether AI can write content. It clearly can. The interesting question is whether you can build infrastructure that runs reliably enough to trust with a public site. We are finding out in public.
 
-Every agent is a standalone Python script that:
-
-- Reads its own config from a sibling YAML file
-- Loads a prompt template and substitutes runtime data using simple string replacement
-- Calls Claude via the Anthropic SDK to process or generate content
-- Writes outputs to a local directory with timestamps
-- Pings a health check URL on success
-- Handles dry-run mode for testing without making real API calls
-- Skips health pings on manual triggers so scheduled monitoring stays clean
-
-The fabrication is the interesting part. A single Claude call generates both the agent code and its prompt template together. We validate that every placeholder in the prompt has a corresponding replacement in the code. If they don't match, we catch it before deployment.
-
-## What the CLI is not
-
-The softcat CLI is not an agent framework. It doesn't manage agent memory, tool registries, or multi-agent coordination. It's an agent *factory*. You describe what you want, it builds and deploys a specialist.
-
-It's also not a hosted platform. Agents run on your machine, on your cron, with your API keys. There's no dashboard, no SaaS, no monthly fee. Just a CLI and a directory of agents.
-
-## What's next
-
-The core pipeline works. We use it daily. The focus now is on making it easier to share and discover agent patterns. Community templates, better output routing, and tighter integration with tools like MCP are all on the roadmap.
-
-If you've been building agents and getting stuck at the "ok but how do I actually run this every day" stage, this is for you.
+If you want to see what it looks like in practice, [/pipeline](/pipeline) shows every run from this morning.


### PR DESCRIPTION
## Summary

- Replaces the old CLI-focused "What is SOFT CAT" post with an accurate description of the six bots that actually run the site
- All bot names, schedules, feeds, and page references now match `bots.json` and live infrastructure
- Follows STYLE.md: no em dashes, British English, short paragraphs, collective voice
- Date updated to 2026-03-13, tags updated from `announcement` to `pipeline`

## Context

The original post described a fictional `softcat` CLI tool with commands like `spawn`, `meow`, `groom`, etc. None of that exists. Now that PR #61 landed the pipeline dashboard and bot telemetry, this post should reflect what's actually running.

## Test plan
- [x] `npm run build` passes (237 pages, 2.80s)
- [x] All internal links reference real pages (/pipeline, /news-and-updates, /thoughts, /radar, /tools, /prompts)
- [x] Bot names and schedules match bots.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)