### PR TITLE
Remove Giscus comments

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## Quick wins
 - [x] Mobile nav — hamburger menu for small screens
 - [x] Sitemap.xml — Astro has built-in support
-- [ ] Giscus comments — GitHub Discussions-powered, no database. Dark theme, thoughts + news pages.
 - [ ] Tags page — browse content by tag
 - [ ] Pagefind search — client-side search across all content
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -10,7 +10,6 @@ interface Props {
   summary?: string;
   backLink: string;
   backLabel: string;
-  showComments?: boolean;
   readingTime?: number;
   generated_by?: string;
   model?: string;
@@ -18,7 +17,7 @@ interface Props {
   cost_usd?: number;
 }
 
-const { title, date, tags = [], summary, backLink, backLabel, showComments = false, readingTime, generated_by, model, generation_time_s, cost_usd } = Astro.props;
+const { title, date, tags = [], summary, backLink, backLabel, readingTime, generated_by, model, generation_time_s, cost_usd } = Astro.props;
 
 const articleSchema: Record<string, unknown> = {
   "@context": "https://schema.org",
@@ -91,37 +90,5 @@ if (tags.length > 0) articleSchema["keywords"] = tags.join(", ");
       <slot />
     </div>
 
-    {showComments && (
-      <section class="mt-16 pt-10 border-t border-surface-light">
-        <h2 class="font-mono text-lg font-bold text-text-bright mb-6 glow-cyan">Discussion</h2>
-        <script
-          src="https://giscus.app/client.js"
-          data-repo="valorifutures/softcat.ai"
-          data-repo-id="R_kgDORXqv_Q"
-          data-category="Announcements"
-          data-category-id="DIC_kwDORXqv_c4C3iEm"
-          data-mapping="pathname"
-          data-strict="0"
-          data-reactions-enabled="1"
-          data-emit-metadata="0"
-          data-input-position="bottom"
-          data-theme="dark_tritanopia"
-          data-lang="en"
-          crossorigin="anonymous"
-          async
-        ></script>
-        <noscript>
-          <p class="text-text-muted font-mono text-sm">
-            Comments require JavaScript.
-            <a
-              href="https://github.com/valorifutures/softcat.ai/discussions"
-              class="text-neon-cyan hover:underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >Join the discussion on GitHub.</a>
-          </p>
-        </noscript>
-      </section>
-    )}
   </article>
 </BaseLayout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -31,10 +31,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <span class="text-neon-cyan mt-0.5">&#9656;</span>
             <span><strong class="text-text-bright">GitHub Pages</strong> hosts this site. GitHub may collect basic server logs. See their <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" class="text-neon-cyan hover:underline" target="_blank" rel="noopener noreferrer">privacy statement</a>.</span>
           </li>
-          <li class="flex items-start gap-2">
-            <span class="text-neon-cyan mt-0.5">&#9656;</span>
-            <span><strong class="text-text-bright">Giscus</strong> powers comments on some pages. It uses GitHub Discussions and requires a GitHub account to comment. See the <a href="https://github.com/giscus/giscus/blob/main/PRIVACY-POLICY.md" class="text-neon-cyan hover:underline" target="_blank" rel="noopener noreferrer">Giscus privacy policy</a>.</span>
-          </li>
         </ul>
       </div>
 

--- a/src/pages/thoughts/[...slug].astro
+++ b/src/pages/thoughts/[...slug].astro
@@ -23,7 +23,6 @@ const readingTime = Math.max(1, Math.ceil(words / 200));
   summary={entry.data.summary}
   backLink="/thoughts"
   backLabel="Thoughts"
-  showComments={true}
   readingTime={readingTime}
   generated_by={entry.data.generated_by}
   model={entry.data.model}


### PR DESCRIPTION
## Summary
- Removed Giscus discussion widget from PostLayout
- Removed `showComments` prop from PostLayout and thoughts pages
- Removed Giscus entry from privacy policy
- Removed Giscus TODO item

🤖 Generated with [Claude Code](https://claude.com/claude-code)