### PR TITLE
Tools page showroom upgrade

### DIFF
--- a/src/components/lab/ToolShowcase.tsx
+++ b/src/components/lab/ToolShowcase.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'preact/hooks';
+
+interface Tool {
+  id: string;
+  name: string;
+  description: string;
+  stat: string;
+  href: string;
+  icon: string;
+  category: string;
+  addedDate: string;
+}
+
+const categories = [
+  { id: 'all', label: 'All', color: 'purple' },
+  { id: 'prompts', label: 'Prompt Engineering', color: 'amber' },
+  { id: 'models', label: 'Model Intelligence', color: 'cyan' },
+  { id: 'cost', label: 'Cost & Tokens', color: 'green' },
+  { id: 'validation', label: 'Validation', color: 'purple' },
+] as const;
+
+type CategoryColor = typeof categories[number]['color'];
+
+const colorMap: Record<string, { glow: string; text: string; border: string; bg: string; dot: string; hex: string }> = {
+  amber: {
+    glow: 'card-glow-amber',
+    text: 'text-neon-amber',
+    border: 'border-l-neon-amber/40',
+    bg: 'bg-neon-amber/10',
+    dot: 'rgba(212, 165, 74, ',
+    hex: '#d4a54a',
+  },
+  cyan: {
+    glow: 'card-glow-cyan',
+    text: 'text-neon-cyan',
+    border: 'border-l-neon-cyan/40',
+    bg: 'bg-neon-cyan/10',
+    dot: 'rgba(90, 184, 212, ',
+    hex: '#5ab8d4',
+  },
+  green: {
+    glow: 'card-glow-green',
+    text: 'text-neon-green',
+    border: 'border-l-neon-green/40',
+    bg: 'bg-neon-green/10',
+    dot: 'rgba(78, 203, 143, ',
+    hex: '#4ecb8f',
+  },
+  purple: {
+    glow: 'card-glow-purple',
+    text: 'text-neon-purple',
+    border: 'border-l-neon-purple/40',
+    bg: 'bg-neon-purple/10',
+    dot: 'rgba(155, 122, 204, ',
+    hex: '#9b7acc',
+  },
+};
+
+const categoryColorFor = (cat: string): CategoryColor => {
+  const found = categories.find((c) => c.id === cat);
+  return found ? found.color : 'purple';
+};
+
+function isNew(addedDate: string): boolean {
+  const added = new Date(addedDate);
+  const now = new Date();
+  const diffDays = (now.getTime() - added.getTime()) / (1000 * 60 * 60 * 24);
+  return diffDays <= 30;
+}
+
+export default function ToolShowcase({ tools }: { tools: Tool[] }) {
+  const [active, setActive] = useState('all');
+
+  const filtered = active === 'all' ? tools : tools.filter((t) => t.category === active);
+
+  return (
+    <div>
+      {/* Category tabs */}
+      <div class="flex flex-wrap gap-2 mb-8">
+        {categories.map((cat) => {
+          const isActive = active === cat.id;
+          const colors = colorMap[cat.color];
+          return (
+            <button
+              key={cat.id}
+              onClick={() => setActive(cat.id)}
+              class={`px-3 py-1.5 rounded-lg font-mono text-xs transition-all cursor-pointer border ${
+                isActive
+                  ? `${colors.bg} ${colors.text} border-current`
+                  : 'bg-surface border-surface-light text-text-muted hover:text-text-bright hover:border-surface-light'
+              }`}
+            >
+              <span
+                class="inline-block w-1.5 h-1.5 rounded-full mr-2"
+                style={isActive ? { backgroundColor: `${colors.dot}1)`, boxShadow: `0 0 6px ${colors.dot}0.5)` } : { backgroundColor: 'rgba(173, 173, 196, 0.3)' }}
+              />
+              {cat.label}
+              {cat.id !== 'all' && (
+                <span class="ml-1.5 opacity-50">
+                  {tools.filter((t) => t.category === cat.id).length}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tool grid */}
+      {filtered.length === 0 ? (
+        <div class="bg-surface border border-surface-light rounded-lg p-8 text-center">
+          <p class="font-mono text-sm text-text-muted">No tools in this category yet.</p>
+        </div>
+      ) : (
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {filtered.map((tool, index) => {
+            const color = categoryColorFor(tool.category);
+            const colors = colorMap[color];
+            const showNew = isNew(tool.addedDate);
+
+            return (
+              <a
+                key={tool.id}
+                href={tool.href}
+                class={`group block relative glass-card rounded-xl ${colors.glow} card-lift border-l-2 ${colors.border} overflow-hidden tool-card`}
+                style={{ animationDelay: `${index * 60}ms`, '--tool-accent': colors.hex } as any}
+              >
+                <div class="p-6">
+                  <div class="flex items-start gap-4">
+                    <span class={`tool-icon font-mono text-lg ${colors.text} shrink-0 mt-0.5`}>
+                      {tool.icon}
+                    </span>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <h3 class="tool-card-title font-mono text-sm font-bold text-text-bright transition-colors">
+                          {tool.name}
+                        </h3>
+                        {showNew && (
+                          <span class="px-1.5 py-0.5 rounded text-[10px] font-mono font-bold bg-neon-green/15 text-neon-green border border-neon-green/20">
+                            NEW
+                          </span>
+                        )}
+                      </div>
+                      <p class="text-sm text-text-muted mt-1.5 leading-relaxed">
+                        {tool.description}
+                      </p>
+                      {/* Quick stat — desktop hover reveal */}
+                      <p class={`font-mono text-xs ${colors.text} mt-2 opacity-50 group-hover:opacity-100 transition-opacity hidden md:block`}>
+                        ▸ {tool.stat}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/tools-manifest.json
+++ b/src/data/tools-manifest.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "token-counter",
+    "name": "Token Counter",
+    "description": "Estimate token counts for Claude, GPT, and Llama models.",
+    "stat": "50+ models supported",
+    "href": "/lab/token-counter",
+    "icon": "#",
+    "category": "cost",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "prompt-builder",
+    "name": "Prompt Builder",
+    "description": "Structured templates for common AI tasks. Fill in the blanks, export the prompt.",
+    "stat": "6 preset templates",
+    "href": "/lab/prompt-builder",
+    "icon": ">_",
+    "category": "prompts",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "markdown-preview",
+    "name": "Markdown Preview",
+    "description": "Write markdown, see it rendered live in the SOFT CAT house style.",
+    "stat": "Live split-pane editor",
+    "href": "/lab/markdown-preview",
+    "icon": "M↓",
+    "category": "prompts",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "model-comparison",
+    "name": "Model Comparison",
+    "description": "Interactive table of AI models. Filter, sort, compare specs and pricing.",
+    "stat": "50+ models, sortable",
+    "href": "/lab/model-comparison",
+    "icon": "⊞",
+    "category": "models",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "prompt-workbench",
+    "name": "Prompt Workbench",
+    "description": "Full prompt IDE. System/user/assistant sections, variables, templates, export.",
+    "stat": "5 built-in templates",
+    "href": "/lab/prompt-workbench",
+    "icon": "⚙",
+    "category": "prompts",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "chat-playground",
+    "name": "Chat Playground",
+    "description": "Chat with AI models using your own API key. Side-by-side model comparison.",
+    "stat": "BYOK via OpenRouter",
+    "href": "/lab/chat-playground",
+    "icon": "◈",
+    "category": "models",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "model-explorer",
+    "name": "Model Explorer",
+    "description": "Visual map of the AI model landscape. Timeline, capabilities, pricing calculator.",
+    "stat": "Card, timeline & pricing views",
+    "href": "/lab/model-explorer",
+    "icon": "◉",
+    "category": "models",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "token-cost",
+    "name": "Token Cost Calculator",
+    "description": "Paste a prompt, pick a model, see the exact API cost before you commit to a stack.",
+    "stat": "Real-time cost estimates",
+    "href": "/lab/token-cost",
+    "icon": "$",
+    "category": "cost",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "prompt-diff",
+    "name": "Prompt Diff",
+    "description": "Compare two prompt versions. See the diff, token delta, and cost difference at a glance.",
+    "stat": "Word-level LCS diff",
+    "href": "/lab/prompt-diff",
+    "icon": "~Δ",
+    "category": "prompts",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "prompt-battle",
+    "name": "Prompt Battle",
+    "description": "A/B test two prompt variants. Paste responses, pick a winner, track your score.",
+    "stat": "Scoreboard + round history",
+    "href": "/lab/prompt-battle",
+    "icon": "⚔",
+    "category": "prompts",
+    "addedDate": "2026-02-01"
+  },
+  {
+    "id": "json-validator",
+    "name": "JSON Output Validator",
+    "description": "Validate AI model JSON output against a schema. Check types, required fields, and structure.",
+    "stat": "Recursive schema checks",
+    "href": "/lab/json-validator",
+    "icon": "{}",
+    "category": "validation",
+    "addedDate": "2026-02-01"
+  }
+]

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,120 +1,86 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import ToolShowcase from '../../components/lab/ToolShowcase';
 import { getCollection } from 'astro:content';
 import { tagDotClass } from '../../utils/tagColor';
+import toolsManifest from '../../data/tools-manifest.json';
 
 const entries = (await getCollection('tools'))
   .filter((e) => !e.data.draft);
 
-const labTools = [
-  {
-    name: 'Token Counter',
-    description: 'Estimate token counts for Claude, GPT, and Llama models.',
-    href: '/lab/token-counter',
-    icon: '#',
-  },
-  {
-    name: 'Prompt Builder',
-    description: 'Structured templates for common AI tasks. Fill in the blanks, export the prompt.',
-    href: '/lab/prompt-builder',
-    icon: '>_',
-  },
-  {
-    name: 'Markdown Preview',
-    description: 'Write markdown, see it rendered live in the SOFT CAT house style.',
-    href: '/lab/markdown-preview',
-    icon: 'M↓',
-  },
-  {
-    name: 'Model Comparison',
-    description: 'Interactive table of AI models. Filter, sort, compare specs and pricing.',
-    href: '/lab/model-comparison',
-    icon: '⊞',
-  },
-  {
-    name: 'Prompt Workbench',
-    description: 'Full prompt IDE. System/user/assistant sections, variables, templates, export.',
-    href: '/lab/prompt-workbench',
-    icon: '⚙',
-  },
-  {
-    name: 'Chat Playground',
-    description: 'Chat with AI models using your own API key. Side-by-side model comparison.',
-    href: '/lab/chat-playground',
-    icon: '◈',
-  },
-  {
-    name: 'Model Explorer',
-    description: 'Visual map of the AI model landscape. Timeline, capabilities, pricing calculator.',
-    href: '/lab/model-explorer',
-    icon: '◉',
-  },
-  {
-    name: 'Token Cost Calculator',
-    description: 'Paste a prompt, pick a model, see the exact API cost before you commit to a stack.',
-    href: '/lab/token-cost',
-    icon: '$',
-  },
-  {
-    name: 'Prompt Diff',
-    description: 'Compare two prompt versions. See the diff, token delta, and cost difference at a glance.',
-    href: '/lab/prompt-diff',
-    icon: '~Δ',
-  },
-  {
-    name: 'Prompt Battle',
-    description: 'A/B test two prompt variants. Paste responses, pick a winner, track your score.',
-    href: '/lab/prompt-battle',
-    icon: '⚔',
-  },
-  {
-    name: 'JSON Output Validator',
-    description: 'Validate AI model JSON output against a schema. Check types, required fields, and structure.',
-    href: '/lab/json-validator',
-    icon: '{}',
-  },
-];
+// Pick featured tool: first tool with "featured: true" in manifest, or fallback to first tool
+const featured = toolsManifest.find((t: any) => t.featured) || toolsManifest[0];
+
+const categoryColors: Record<string, { text: string; bg: string; border: string; glowVar: string; hex: string }> = {
+  prompts: { text: 'text-neon-amber', bg: 'bg-neon-amber/10', border: 'border-neon-amber/30', glowVar: 'rgba(212, 165, 74, 0.12)', hex: '#d4a54a' },
+  models: { text: 'text-neon-cyan', bg: 'bg-neon-cyan/10', border: 'border-neon-cyan/30', glowVar: 'rgba(90, 184, 212, 0.12)', hex: '#5ab8d4' },
+  cost: { text: 'text-neon-green', bg: 'bg-neon-green/10', border: 'border-neon-green/30', glowVar: 'rgba(78, 203, 143, 0.12)', hex: '#4ecb8f' },
+  validation: { text: 'text-neon-purple', bg: 'bg-neon-purple/10', border: 'border-neon-purple/30', glowVar: 'rgba(155, 122, 204, 0.12)', hex: '#9b7acc' },
+};
+
+const featuredColor = categoryColors[featured.category] || categoryColors.models;
 ---
 
 <BaseLayout title="Tools" description="Interactive AI tools and write-ups." breadcrumbs={[{name: 'Tools', url: '/tools'}]}>
   <div class="max-w-4xl mx-auto px-6 py-16">
-    <header class="mb-8">
+    <header class="mb-10">
       <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>
       <h1 class="font-mono text-3xl font-bold text-text-bright glow-purple">Tools</h1>
-      <p class="text-text-muted mt-2">Interactive tools and write-ups. All client-side, nothing leaves your browser.</p>
+      <p class="text-text-muted mt-2">Interactive tools built for people who work with AI. All client-side, nothing leaves your browser.</p>
     </header>
-    <div class="section-banner mb-6" style="height: 180px; --banner-accent: rgba(155, 122, 204, 0.12); --banner-accent-mid: rgba(155, 122, 204, 0.04)" aria-hidden="true"></div>
 
-    <!-- Interactive tools -->
-    <h2 class="font-mono text-lg font-bold text-text-bright flex items-center gap-2 mb-5">
-      <span class="text-neon-green">&#9632;</span>
-      Interactive
-    </h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
-      {labTools.map((tool) => (
-        <a
-          href={tool.href}
-          class="block bg-surface border border-surface-light rounded-lg p-6 card-glow card-glow-green group"
-        >
-          <div class="flex items-start gap-4">
-            <span class="font-mono text-lg text-neon-green shrink-0 mt-0.5">{tool.icon}</span>
-            <div>
-              <h3 class="font-mono text-sm font-bold text-text-bright group-hover:text-neon-green transition-colors">
-                {tool.name}
-              </h3>
-              <p class="text-sm text-text-muted mt-1">{tool.description}</p>
+    <!-- Featured tool spotlight -->
+    <div class="mb-10">
+      <div class="flex items-center gap-2 mb-4">
+        <span class="font-mono text-xs text-text-muted tracking-wider uppercase">Featured</span>
+        <div class="flex-1 h-px bg-surface-light/50"></div>
+      </div>
+      <a
+        href={featured.href}
+        class="tool-card group block relative overflow-hidden rounded-xl border border-surface-light/50 hover:border-surface-light transition-all"
+        style={`--tool-accent: ${featuredColor.hex}; background: radial-gradient(ellipse at 30% 50%, ${featuredColor.glowVar} 0%, transparent 60%), linear-gradient(135deg, rgba(20, 20, 30, 0.9) 0%, rgba(30, 30, 48, 0.7) 100%);`}
+      >
+        <div class="p-8 md:p-10 flex items-start gap-6">
+          <span class={`tool-icon font-mono text-3xl ${featuredColor.text} shrink-0 mt-1`}>
+            {featured.icon}
+          </span>
+          <div class="min-w-0">
+            <h2 class="tool-card-title font-mono text-xl font-bold text-text-bright transition-colors">
+              {featured.name}
+            </h2>
+            <p class="text-text-muted mt-2 leading-relaxed max-w-lg">
+              {featured.description}
+            </p>
+            <div class="flex items-center gap-4 mt-4">
+              <span class={`font-mono text-xs ${featuredColor.text} opacity-70`}>
+                ▸ {featured.stat}
+              </span>
+              <span class={`inline-flex items-center gap-1.5 px-3 py-1 rounded-lg ${featuredColor.bg} border ${featuredColor.border} font-mono text-xs ${featuredColor.text} group-hover:opacity-100 opacity-80 transition-opacity`}>
+                Try it &rarr;
+              </span>
             </div>
           </div>
-        </a>
-      ))}
+        </div>
+      </a>
+    </div>
+
+    <!-- Interactive tools -->
+    <div class="mb-12">
+      <div class="flex items-center gap-2 mb-6">
+        <span class="font-mono text-xs text-text-muted tracking-wider uppercase">Interactive</span>
+        <span class="font-mono text-xs text-text-muted/50">{toolsManifest.length}</span>
+        <div class="flex-1 h-px bg-surface-light/50"></div>
+      </div>
+      <ToolShowcase client:load tools={toolsManifest} />
     </div>
 
     <!-- Tool write-ups -->
     <div class="glow-divider mb-8" style="--divider-color: rgba(155, 122, 204, 0.15)"></div>
-    <h2 class="font-mono text-lg font-bold text-text-bright flex items-center gap-2 mb-5">
-      <span class="text-neon-purple">&#9632;</span>
-      Write-ups
-    </h2>
+    <div class="flex items-center gap-2 mb-6">
+      <span class="font-mono text-xs text-text-muted tracking-wider uppercase">Write-ups</span>
+      {entries.length > 0 && <span class="font-mono text-xs text-text-muted/50">{entries.length}</span>}
+      <div class="flex-1 h-px bg-surface-light/50"></div>
+    </div>
 
     {entries.length === 0 ? (
       <div class="bg-surface border border-surface-light rounded-lg p-8 text-center">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -277,6 +277,30 @@ body {
   .card-lift:hover {
     transform: none;
   }
+  .tool-icon {
+    animation: none !important;
+  }
+}
+
+/* Tool card — accent-driven hover */
+.tool-card:hover .tool-card-title {
+  color: var(--tool-accent, var(--color-neon-purple));
+}
+
+/* Tool icon hover animation */
+@keyframes icon-pulse {
+  0%, 100% { opacity: 1; text-shadow: 0 0 6px currentColor; }
+  50% { opacity: 0.7; text-shadow: 0 0 12px currentColor; }
+}
+
+.tool-icon {
+  display: inline-block;
+  transition: transform 0.3s ease, text-shadow 0.3s ease;
+}
+
+.tool-card:hover .tool-icon {
+  animation: icon-pulse 1.2s ease-in-out infinite;
+  transform: scale(1.1);
 }
 
 /* Blinking cursor animation */


### PR DESCRIPTION
## Summary
- Replace static tools grid with a dynamic showroom page
- Featured tool spotlight with radial glow background and animated icon
- Category filter tabs: Prompt Engineering (amber), Model Intelligence (cyan), Cost & Tokens (green), Validation (purple)
- Color-coded glass cards with hover icon pulse animations, quick-stat lines, and auto NEW badges (30-day window)
- Tool data extracted to `tools-manifest.json` — bot can update `featured` field and add new tools

## Test plan
- [ ] `npm run build` passes clean
- [ ] Visit `/tools` — featured spotlight renders with radial glow and icon animation
- [ ] Click each category tab — grid filters correctly, counts match
- [ ] Hover tool cards on desktop — icon pulses, title changes to accent color, stat line fades in
- [ ] Check mobile viewport — no hover previews, clean card layout
- [ ] Verify write-ups section still renders below the interactive grid
- [ ] Check `prefers-reduced-motion` — animations disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)