### PR TITLE
fix(dispatch): submit subscribe form directly to Buttondown

### DIFF
--- a/src/components/Dispatch.astro
+++ b/src/components/Dispatch.astro
@@ -12,7 +12,9 @@
     </p>
 
     <form
-      id="dispatch-form"
+      action="https://buttondown.com/api/emails/embed-subscribe/softcatai"
+      method="post"
+      target="_blank"
       class="flex gap-2 max-w-md"
     >
       <input
@@ -29,52 +31,5 @@
         subscribe
       </button>
     </form>
-    <p id="dispatch-msg" class="font-mono text-xs mt-3 hidden"></p>
   </div>
 </section>
-
-<script>
-  const form = document.getElementById('dispatch-form') as HTMLFormElement;
-  const msg = document.getElementById('dispatch-msg') as HTMLParagraphElement;
-  const btn = form.querySelector('button') as HTMLButtonElement;
-
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const email = new FormData(form).get('email') as string;
-    btn.textContent = 'sending...';
-    btn.disabled = true;
-    msg.classList.add('hidden');
-
-    try {
-      const res = await fetch(
-        'https://buttondown.com/api/emails/embed-subscribe/softcatai',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: `email=${encodeURIComponent(email)}`,
-        }
-      );
-
-      // Buttondown returns 302 or 200 on success, but fetch follows redirects
-      // so we check for any 2xx/3xx response
-      if (res.ok || res.redirected) {
-        msg.textContent = 'Check your inbox to confirm. Welcome aboard.';
-        msg.className = 'font-mono text-xs mt-3 text-neon-green';
-        form.reset();
-      } else {
-        msg.textContent = 'Something went wrong. Try again?';
-        msg.className = 'font-mono text-xs mt-3 text-neon-amber';
-      }
-    } catch {
-      // CORS or network error — fall back to direct form submission
-      form.removeEventListener('submit', () => {});
-      form.action = 'https://buttondown.com/api/emails/embed-subscribe/softcatai';
-      form.method = 'post';
-      form.submit();
-      return;
-    }
-
-    btn.textContent = 'subscribe';
-    btn.disabled = false;
-  });
-</script>


### PR DESCRIPTION
## Summary
- Buttondown's `embed-subscribe/softcatai` endpoint now requires a Cloudflare Turnstile CAPTCHA and returns HTTP 400 with a verification page on raw POSTs.
- The old fetch-based handler in `Dispatch.astro` treated the 400 as a generic error and showed "Something went wrong" — the CAPTCHA page was never reached, so subscribes silently failed.
- Replaced the JS handler with a plain form POST + `target="_blank"`. Browser opens Buttondown's verify page in a new tab; user stays on softcat.ai.

## Test plan
- [x] `npm run build` exits 0 (440 pages)
- [ ] On preview/prod: enter test email, click subscribe, confirm new tab opens to Buttondown verify page
- [ ] Solve CAPTCHA, confirm Buttondown sends confirmation email

🤖 Generated with [Claude Code](https://claude.com/claude-code)