### PR TITLE
auto: add glossary entry for Test-Time Training (TTT)

### DIFF
--- a/src/content/glossary/test-time-training.md
+++ b/src/content/glossary/test-time-training.md
@@ -14,7 +14,7 @@ related:
 draft: false
 ---
 
-Test-Time Training (TTT) is a method where a model continues learning during inference itself, running gradient updates using the specific input it has been given as training data. Unlike standard inference where model weights are frozen, TTT lets the model adapt to new context without a full retraining cycle, giving it a form of working memory that is active for the duration of a session. NVIDIA highlighted this approach in March 2026 as a solution to long-context memory that maintains constant inference latency regardless of how much context is provided.
+Test-Time Training (TTT) is a method where a model continues learning during inference itself, running gradient updates using the specific input it has been given as training data. Unlike standard inference where model weights are frozen, TTT lets the model adapt to new context without a full retraining cycle, giving it a form of working memory that is active for the duration of a session. [NVIDIA highlighted this approach in March 2026](https://developer.nvidia.com/blog/reimagining-llm-memory-using-context-as-training-data-unlocks-models-that-learn-at-test-time) as a solution to long-context memory that maintains constant inference latency regardless of how much context is provided.
 
 In practice, a TTT-enabled model can be handed a 500-page technical manual at inference time and update its own weights to better answer questions about that document, without any offline fine-tuning step.
 

--- a/src/content/glossary/test-time-training.md
+++ b/src/content/glossary/test-time-training.md
@@ -14,7 +14,7 @@ related:
 draft: false
 ---
 
-Test-Time Training (TTT) is a method where a model continues learning during inference itself, running gradient updates using the specific input it has been given as training data. Unlike standard inference where model weights are frozen, TTT lets the model adapt to new context without a full retraining cycle, giving it a form of working memory that is active for the duration of a session. [NVIDIA highlighted this approach in March 2026](https://developer.nvidia.com/blog/reimagining-llm-memory-using-context-as-training-data-unlocks-models-that-learn-at-test-time) as a solution to long-context memory that maintains constant inference latency regardless of how much context is provided.
+Test-Time Training (TTT) is a method where a model continues learning during inference itself, running gradient updates using the specific input it has been given as training data. Unlike standard inference where model weights are frozen, TTT lets the model adapt to new context without a full retraining cycle, giving it a form of working memory that is active for the duration of a session. [NVIDIA highlighted this approach in January 2026](https://developer.nvidia.com/blog/reimagining-llm-memory-using-context-as-training-data-unlocks-models-that-learn-at-test-time) as a solution to long-context memory that maintains constant inference latency regardless of how much context is provided.
 
 In practice, a TTT-enabled model can be handed a 500-page technical manual at inference time and update its own weights to better answer questions about that document, without any offline fine-tuning step.
 


### PR DESCRIPTION
Closes #75

## Changes
- Added glossary entry for Test-Time Training (TTT) at `src/content/glossary/test-time-training.md`
- Includes source link to NVIDIA's blog post on TTT
- Tags: training, inference, memory, efficiency, research
- Related terms: sparse-attention, continual-learning

## Verification
- Build passes: yes
- Follows STYLE.md: yes

---
*Automated PR by SOFT CAT Builder*