### PR TITLE
Horizon prereqs: longer radar archive + full git history on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the horizon page's Weekly Shift Log module can
+          # use `git log` as a fallback when shifts.json is missing.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/bot/radar_bot.py
+++ b/bot/radar_bot.py
@@ -55,7 +55,9 @@ CATEGORIES = [
 ]
 
 # Rolling archive depth
-MAX_ARCHIVE_DAYS = 30
+# Bumped 30 -> 365 to keep radar entries alive long enough for the horizon bot
+# to consider them for promotion to past.json (60-day eligibility window).
+MAX_ARCHIVE_DAYS = 365
 
 load_dotenv(BOT_DIR / ".env")
 

--- a/src/pages/radar/[date].astro
+++ b/src/pages/radar/[date].astro
@@ -4,12 +4,15 @@ import RadarFeaturedCard from '../../components/RadarFeaturedCard.astro';
 import RadarPickCard from '../../components/RadarPickCard.astro';
 
 import manifest from '../../data/radar/index.json';
+import { RADAR_VISIBLE_DAYS } from '../../utils/radar';
 
 export function getStaticPaths() {
-  return manifest.dates.map((date) => ({
+  return manifest.dates.slice(0, RADAR_VISIBLE_DAYS).map((date) => ({
     params: { date },
   }));
 }
+
+const visibleDates = manifest.dates.slice(0, RADAR_VISIBLE_DAYS);
 
 const { date } = Astro.params;
 
@@ -22,9 +25,9 @@ function formatDate(dateStr: string): string {
   return d.toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
 }
 
-const dateIndex = manifest.dates.indexOf(date!);
-const newerDate = dateIndex > 0 ? manifest.dates[dateIndex - 1] : null;
-const olderDate = dateIndex < manifest.dates.length - 1 ? manifest.dates[dateIndex + 1] : null;
+const dateIndex = visibleDates.indexOf(date!);
+const newerDate = dateIndex > 0 ? visibleDates[dateIndex - 1] : null;
+const olderDate = dateIndex >= 0 && dateIndex < visibleDates.length - 1 ? visibleDates[dateIndex + 1] : null;
 ---
 
 <BaseLayout title={`The Radar — ${date}`} description={`AI product launches from Product Hunt on ${date}.`}>

--- a/src/utils/radar.ts
+++ b/src/utils/radar.ts
@@ -1,0 +1,8 @@
+// Public-facing radar page count.
+//
+// The bot's MAX_ARCHIVE_DAYS (in bot/radar_bot.py) may be much larger so the
+// horizon bot has enough manifest history to scan for promotion candidates,
+// but we only render the most recent N days as actual /radar/<date> routes
+// to keep the public site bounded. Older dates stay in the manifest and on
+// disk for the horizon bot's use, just not as public pages.
+export const RADAR_VISIBLE_DAYS = 30;


### PR DESCRIPTION
## Summary

Step 0 of the AI Horizon Map v1 sequence. Two surgical changes plus a side-effect fix uncovered by pre-landing review:

**Bot side**
- `bot/radar_bot.py:60` — `MAX_ARCHIVE_DAYS` 30 → 365 so the future horizon bot has enough manifest history (60-day eligibility window with margin) to scan radar entries for promotion to the past lane.

**CI side**
- `.github/workflows/deploy.yml` — `actions/checkout` gains `fetch-depth: 0` so the upcoming Weekly Shift Log module can fall back to `git log` at build time when `shifts.json` is unavailable.

**Render side (fix added during pre-landing review)**
- `src/utils/radar.ts` — new file exporting `RADAR_VISIBLE_DAYS = 30`.
- `src/pages/radar/[date].astro` — `getStaticPaths()` now slices `manifest.dates` at `RADAR_VISIBLE_DAYS`, and the prev/next nav uses the same sliced array so boundary pages don't link to ungenerated routes.

The render-side fix decouples bot-side manifest depth (365, what the horizon bot needs) from public-site route count (30, what's actually rendered). Without the slice the radar route count would have grown 12x as the manifest filled up — the public site stays bounded at exactly 30 visible days.

## Test Coverage

No test framework in this repo by design — the verification gate is `npm run build` which exited 0 with 470 pages built. Test bootstrap declined per CLAUDE.md ("NEVER add npm dependencies").

## Pre-Landing Review

Two passes:

**Pass 1 (bot + CI only):** No critical issues. One informational note flagged: `MAX_ARCHIVE_DAYS` is the only retention mechanism in `radar_bot.py` (no file-deletion logic). 45 radar files exist on disk today, manifest had 30 → ~15 files were already orphaned. The horizon bot's promotion scanner (Step 6 of the design) should scan `src/data/radar/*.json` directly via filesystem, not via the manifest. Design doc already says this so it's just an invariant to document in `horizon_bot.py` when it lands.

**Adversarial pass (Claude subagent):** Found a real high-confidence issue I missed in my own pass — `getStaticPaths()` in `src/pages/radar/[date].astro` returns one page per `manifest.dates` entry, so the cap bump would have grown the radar route count from 30 to ~366 over a year. **Fixed in commit 48b6d2d** by introducing `RADAR_VISIBLE_DAYS=30` and slicing `manifest.dates` in both `getStaticPaths()` and the prev/next navigation.

## Deferred to TODOS.md (P2/P3, pre-existing, not this PR's job)

- No file deletion in `radar_bot.py` — disk grows unbounded; orphan files exist today
- Eager `import.meta.glob` in `src/pages/search-index.json.ts` already loads all disk files, so the search index is already growing — pre-existing, not caused by the cap bump
- `dayKey` undefined edge case in `[date].astro` when manifest references a missing file — should warn at build time
- `radar_bot.py` `git stash pop` after `git pull --rebase` is fragile under concurrent CI

## Test plan

- [x] `npm run build` exits 0 (470 pages, ~3.8s)
- [x] Pre-landing review — no critical issues; adversarial-found side effect fixed in 48b6d2d
- [x] Boundary cases for `visibleDates` slicing walked through (empty, 1 entry, 30 entries, 365 entries)
- [ ] After merge: confirm next bot run still produces a valid `index.json` and that `/radar/<date>` routes still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)