### PR TITLE
Bot drift cleanup + flag two real bot bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ __pycache__/
 
 # jetbrains setting folder
 .idea/
+
+# gstack skill workspace (per-project state, never committed)
+.gstack/

--- a/src/data/pipeline/runs.json
+++ b/src/data/pipeline/runs.json
@@ -2646,5 +2646,22 @@
     "output_files": [
       "src/content/thoughts/2026-04-11-knowledge-distillation-is-just-academic-procrastination-disg.md"
     ]
+  },
+  {
+    "bot": "radar_bot",
+    "timestamp": "2026-04-11T09:30:53.698156+00:00",
+    "status": "success",
+    "duration_s": 47.0,
+    "feeds_scanned": 10,
+    "items_found": 67,
+    "items_rejected": 61,
+    "items_published": 6,
+    "model": "claude-sonnet-4-20250514",
+    "cost_usd": 0.0679,
+    "input_tokens": 11134,
+    "output_tokens": 2299,
+    "output_files": [
+      "src/data/radar/2026-04-11.json"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Cleans up the bot drift sitting in `git stash` on this machine and surfaces two real bugs in the bot pipeline that have been silently corrupting data for weeks. Two small commits, no risky changes.

### What's in this PR

1. **`chore: ignore .gstack/ workspace directory`** — adds `.gstack/` to `.gitignore`. The gstack skill creates a per-project workspace at the repo root for session state, learnings, and review logs. It should never be committed.

2. **`bot: backfill missed radar_bot run-log entry (2026-04-11)`** — appends today's stranded radar_bot pipeline-log entry to `runs.json`. The radar data file itself was already committed in `1e79fc7`, but the run-log entry was orphaned by the ordering bug described below.

## Two real bot bugs surfaced during this cleanup

### Bug 1: model_bot is hallucinating prices

The `model_bot` cron at `04:00 UTC` daily has been writing **factually wrong** model price/context updates to `models.json`. These have been stranded in stashes across at least 4 sessions.

Verified today against live sources:

| What model_bot proposed | What's actually true | Source |
|---|---|---|
| Mistral Small 3.1 input price `$0.03/M` | **`$0.20/M`** | [devtk.ai pricing 2026](https://devtk.ai/en/blog/mistral-api-pricing-guide-2026/), [burnwise.io](https://www.burnwise.io/ai-pricing/mistral) |
| Mistral Small 3.1 output price `$0.11/M` | **`$0.60/M`** | same |
| Claude Sonnet 4.5 (entry: "Claude 4") context `1M` | **`200K` default**; 1M was a beta retiring **2026-04-30** | [platform.claude.com docs](https://platform.claude.com/docs/en/build-with-claude/context-windows) |

The Mistral hallucination has been recurring across stashes from 2026-03-29, 2026-03-30, and today's session. The bot's price-fetching logic is producing fabricated numbers, probably from an ungrounded LLM call without source citations.

**Action needed:** investigate `bot/model_data_bot.py` — likely needs source-grounded fetching with manual verification of any detected price changes.

### Bug 2: pipeline_log ordering bug — every bot commit lags one entry behind

Look at any `bot: add radar data` commit:

```
$ git show 1e79fc7 -- src/data/pipeline/runs.json | grep -A2 '"bot"'
+    "bot": "thoughts_bot",
+    "timestamp": "2026-04-11T08:00:25.267314+00:00",
```

The `radar_bot` commit contains a `thoughts_bot` entry. Same in yesterday's `0c58e52` and probably every previous radar commit. Each bot's `git commit` step runs **before** its `pipeline_log` call appends the entry, so the entry stays uncommitted in the working tree until the next bot picks it up. **radar_bot is the last bot of the day, so its entry never gets picked up at all** — that's why this PR has to backfill it.

Two tactical fixes for `bot/`:
1. Move the `pipeline_log` call to **before** `git add + git commit` in each bot.
2. Or do `git add src/data/pipeline/runs.json` as a final step in a separate "log only" commit at the end of each bot run.

Even better: a wrapper script that ensures the entry is in the staged files before any bot commit fires.

## Stashes being dropped after this PR merges

After this PR is in, the following stashes will all be safe to drop because their useful content is now committed and their `models.json` content is the hallucinated data documented above:

| Stash | Reason for drop |
|---|---|
| `stash@{0}` main-bot-drift-2 | Backfilled in this PR's commit 2 |
| `stash@{1}` main-bot-drift-pre-horizon | `.gitignore` in commit 1; models.json hallucinated |
| `stash@{2}` horizon-session bot artifacts | Old radar entry already irrelevant; models.json hallucinated |
| `stash@{3}` 2026-03-30 | Stale radar entry; models.json hallucinated |
| `stash@{4}` 2026-03-29 | Stale radar entry; models.json hallucinated |
| `stash@{5}` 2026-02-27 | Old hallucinated Kimi data |

I'll drop them in a follow-up after merge confirmation. Drops are reversible from `git fsck --unreachable` for ~30 days if anything goes wrong.

## Test plan

- [ ] `npm run build` exits 0
- [ ] `git log --oneline bot-drift-cleanup ^main` shows the two expected commits
- [ ] `git diff main..bot-drift-cleanup` shows only `.gitignore` (1 line) and `runs.json` (17 lines)
- [ ] No `models.json` changes in this PR (intentional — those would be hallucinated)
- [ ] After merge: tomorrow's `model_bot` run will produce a fresh drift; bug remains until `bot/model_data_bot.py` is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)