### PR TITLE
Horizon Now seed (6 patterns) + static renderer at /horizon

### DIFF
--- a/src/data/horizon/now.json
+++ b/src/data/horizon/now.json
@@ -1,1 +1,111 @@
-[]
+[
+  {
+    "id": "now-2026-04-open-weight-reasoning-frontier",
+    "lane": "now",
+    "title": "Open-weight reasoning models match the frontier and undercut the price",
+    "date": "2026-04-10",
+    "themes": ["models", "infrastructure", "enterprise"],
+    "signal_type": "inflection",
+    "confidence": "confirmed",
+    "why_it_matters": "GLM-5.1 (Z.AI) ships as a 754B open-weight agentic model that hits SOTA on SWE-Bench Pro and sustains 8-hour autonomous execution at roughly a third of frontier API cost. Three distinct moats collapse into one release: open weights, frontier capability, agentic competence. Direct continuation of the DeepSeek-R1 thread from January.",
+    "implication": "If your stack still routes reasoning through a paid API by default, the math has changed. Self-hosted frontier reasoning is no longer a research curiosity.",
+    "evidence": [
+      { "type": "radar", "ref": "2026-04-08", "label": "GLM-5.1 (Z.AI), 754B open-weight agentic model, SWE-Bench Pro SOTA" },
+      { "type": "thought", "ref": "2026-04-03-open-source-reasoning-models-just-made-the-api-economy-irrel", "label": "Open source reasoning models just made the API economy irrelevant" }
+    ],
+    "related": ["past-2025-deepseek-r1"],
+    "added": "2026-04-10"
+  },
+  {
+    "id": "now-2026-04-agent-production-ops",
+    "lane": "now",
+    "title": "The agent production-ops layer is crystallising",
+    "date": "2026-04-10",
+    "themes": ["agents", "infrastructure", "enterprise"],
+    "signal_type": "trend",
+    "confidence": "emerging",
+    "why_it_matters": "Three independent launches in three days, each targeting a different layer of the agent production stack: BotCTL (process management, billed as systemd for agents), OnCell.ai (per-user isolation), Relvy (automated on-call runbooks, YC F24). These are problems that only matter once agents are actually being deployed in production, which means agents are actually being deployed in production.",
+    "implication": "Building on agents in production now means picking from a real toolkit, not duct-taping cron jobs and shell scripts. The stack is shipping faster than the frameworks.",
+    "evidence": [
+      { "type": "radar", "ref": "2026-04-09", "label": "BotCTL, process manager for autonomous AI agents" },
+      { "type": "radar", "ref": "2026-04-07", "label": "OnCell.ai, per-user isolated environments for AI agents" },
+      { "type": "radar", "ref": "2026-04-10", "label": "Relvy (YC F24), automated on-call runbooks via agents" },
+      { "type": "thought", "ref": "2026-03-23-production-deployment-is-the-new-frontier-research", "label": "Production deployment is the new frontier research" }
+    ],
+    "added": "2026-04-10"
+  },
+  {
+    "id": "now-2026-04-tool-calling-protocols",
+    "lane": "now",
+    "title": "Tool-calling and agent-messaging protocols are hardening into infrastructure",
+    "date": "2026-04-10",
+    "themes": ["agents", "infrastructure"],
+    "signal_type": "trend",
+    "confidence": "emerging",
+    "why_it_matters": "AgentDM (agent-to-agent over MCP and A2A), QVeris (10k capabilities discoverable via one protocol), Postagent (Postman-style CLI for agents), and ZeroID (OIDF-based agent identity) all landed within two days. The pattern is the same shape MCP started in late 2024. Agent infrastructure stops being framework wars and starts being shared plumbing.",
+    "implication": "If you are picking an agent framework today, prefer the ones that compose over the protocol layer (MCP, A2A) rather than locking you into a single vendor's tool surface.",
+    "evidence": [
+      { "type": "radar", "ref": "2026-04-09", "label": "AgentDM, agent-to-agent messaging over MCP and A2A" },
+      { "type": "radar", "ref": "2026-04-09", "label": "QVeris, 10k capabilities discoverable via one protocol" },
+      { "type": "radar", "ref": "2026-04-10", "label": "Postagent, Postman-style CLI for AI agents" },
+      { "type": "radar", "ref": "2026-04-09", "label": "ZeroID, OIDF-based identity for AI agents" },
+      { "type": "thought", "ref": "2026-04-08-tool-calling-just-turned-function-composition-into-a-runtime", "label": "Tool calling just turned function composition into a runtime circus" }
+    ],
+    "related": ["past-2024-model-context-protocol"],
+    "added": "2026-04-10"
+  },
+  {
+    "id": "now-2026-04-os-as-environment",
+    "lane": "now",
+    "title": "OS-as-environment is becoming the standard for agent training",
+    "date": "2026-04-10",
+    "themes": ["agents", "infrastructure", "code"],
+    "signal_type": "inflection",
+    "confidence": "emerging",
+    "why_it_matters": "OSGym ships infrastructure to manage 1,000+ OS replicas at $0.23 per day for computer-use agent research. That is not a product launch, it is a capability. Parallel rollouts on real operating systems become economically viable. Astropad Workbench and TUI-use round out the pattern: agents need bodies, and the bodies are computers.",
+    "implication": "Computer-use agents are about to be cheap to train. If your product touches workflows that humans currently do in a browser or terminal, expect competitive pressure within six months.",
+    "evidence": [
+      { "type": "radar", "ref": "2026-04-09", "label": "OSGym, 1,000+ OS replicas at $0.23 per day for computer-use agent research" },
+      { "type": "radar", "ref": "2026-04-09", "label": "Astropad Workbench, low-latency remote desktop for AI agents" },
+      { "type": "radar", "ref": "2026-04-09", "label": "TUI-use, agents controlling interactive terminal programs" },
+      { "type": "thought", "ref": "2026-03-29-rollout-infrastructure-just-became-the-new-model-training", "label": "Rollout infrastructure just became the new model training" }
+    ],
+    "added": "2026-04-10"
+  },
+  {
+    "id": "now-2026-04-local-first-inference",
+    "lane": "now",
+    "title": "Local-first inference moves from edge case to default for new launches",
+    "date": "2026-04-10",
+    "themes": ["models", "infrastructure", "interfaces"],
+    "signal_type": "trend",
+    "confidence": "emerging",
+    "why_it_matters": "Four launches in five days defaulting to local-first inference rather than cloud: Google's offline AI dictation app on iOS using Gemma, Imbue's Bouncer (on-device LLM for Twitter feed control), QVAC SDK (universal JS for local AI), and Meta's EUPE (sub-100M-parameter vision encoder family). Notable that Google itself is shipping offline-first using its own models. That is the shift, not any single launch.",
+    "implication": "The economics are flipping. Default to local for new launches unless you have a specific reason to go cloud-first. Users increasingly notice the difference.",
+    "evidence": [
+      { "type": "radar", "ref": "2026-04-08", "label": "Google AI Dictation, offline-first iOS app using Gemma" },
+      { "type": "radar", "ref": "2026-04-10", "label": "Bouncer (Imbue), on-device LLM for Twitter feed control" },
+      { "type": "radar", "ref": "2026-04-10", "label": "QVAC SDK, universal JavaScript SDK for local AI" },
+      { "type": "radar", "ref": "2026-04-07", "label": "EUPE (Meta), sub-100M-parameter vision encoder family" },
+      { "type": "thought", "ref": "2026-04-04-token-taxes-are-just-cloud-computing", "label": "Token taxes are just cloud computing's final power grab" }
+    ],
+    "added": "2026-04-10"
+  },
+  {
+    "id": "now-2026-04-multimodal-reasoning-frontier",
+    "lane": "now",
+    "title": "Multimodal reasoning becomes a frontier-race table-stakes capability",
+    "date": "2026-04-10",
+    "themes": ["models", "interfaces", "creativity"],
+    "signal_type": "trend",
+    "confidence": "emerging",
+    "why_it_matters": "Meta Superintelligence Lab released Muse Spark, a multimodal reasoning model with thought compression and parallel agents. Frontend-VisualQA (Yutori AI) gave coding agents visual verification of their own UI work. EUPE shows compact vision encoders can rival specialists. Multimodal reasoning is no longer a frontier-lab talking point. It is becoming a baseline capability across the stack.",
+    "implication": "Vision is no longer a separate capability you bolt onto a model. Plan for it as a baseline assumption when designing agent workflows.",
+    "evidence": [
+      { "type": "radar", "ref": "2026-04-10", "label": "Muse Spark (Meta Superintelligence Lab), multimodal reasoning with thought compression" },
+      { "type": "radar", "ref": "2026-04-08", "label": "Frontend-VisualQA (Yutori AI), visual verification for coding agents" },
+      { "type": "radar", "ref": "2026-04-07", "label": "EUPE (Meta), compact vision encoders rivalling specialists" }
+    ],
+    "added": "2026-04-10"
+  }
+]

--- a/src/pages/horizon.astro
+++ b/src/pages/horizon.astro
@@ -269,52 +269,6 @@ function formatYear(dateStr: string): string {
   </section>
 
   <!-- ============================================================ -->
-  <!-- PAST LANE                                                     -->
-  <!-- ============================================================ -->
-  <section class="max-w-5xl mx-auto px-6 mb-16">
-    <div class="flex items-baseline justify-between mb-6">
-      <h2 class="font-mono text-2xl font-bold text-text-bright glow-purple">
-        Past
-      </h2>
-      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
-        what mattered, and when
-      </span>
-    </div>
-
-    <div class="space-y-10">
-      {pastYears.map((year) => (
-        <div>
-          <h3 class="font-mono text-sm text-neon-purple/80 uppercase tracking-widest mb-4 sticky top-0">
-            {year}
-          </h3>
-          <div class="space-y-4">
-            {pastByYear[year].map((entry) => (
-              <article class="glass-card rounded-lg p-5 card-glow-purple card-lift">
-                <div class="flex items-baseline justify-between gap-4 mb-2">
-                  <h4 class="font-mono text-base text-text-bright font-semibold">
-                    {entry.data.title}
-                  </h4>
-                  <span class="shrink-0 font-mono text-[11px] text-text-muted/70">
-                    {formatDate(entry.data.date)}
-                  </span>
-                </div>
-                <p class="text-sm text-text-muted leading-relaxed mb-3">
-                  {entry.data.why_it_matters}
-                </p>
-                <div class="flex flex-wrap gap-1.5">
-                  {entry.data.themes.map((t) => (
-                    <span class="tag-badge"><span class="tag-dot tag-dot-purple" aria-hidden="true"></span>{t}</span>
-                  ))}
-                </div>
-              </article>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  </section>
-
-  <!-- ============================================================ -->
   <!-- NEXT LANE                                                     -->
   <!-- ============================================================ -->
   <section class="max-w-5xl mx-auto px-6 mb-16">
@@ -395,6 +349,52 @@ function formatYear(dateStr: string): string {
     ) : (
       <div>{/* Future renderer for debates */}</div>
     )}
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- PAST LANE                                                     -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-purple">
+        Past
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        what mattered, and when
+      </span>
+    </div>
+
+    <div class="space-y-10">
+      {pastYears.map((year) => (
+        <div>
+          <h3 class="font-mono text-sm text-neon-purple/80 uppercase tracking-widest mb-4 sticky top-0">
+            {year}
+          </h3>
+          <div class="space-y-4">
+            {pastByYear[year].map((entry) => (
+              <article class="glass-card rounded-lg p-5 card-glow-purple card-lift">
+                <div class="flex items-baseline justify-between gap-4 mb-2">
+                  <h4 class="font-mono text-base text-text-bright font-semibold">
+                    {entry.data.title}
+                  </h4>
+                  <span class="shrink-0 font-mono text-[11px] text-text-muted/70">
+                    {formatDate(entry.data.date)}
+                  </span>
+                </div>
+                <p class="text-sm text-text-muted leading-relaxed mb-3">
+                  {entry.data.why_it_matters}
+                </p>
+                <div class="flex flex-wrap gap-1.5">
+                  {entry.data.themes.map((t) => (
+                    <span class="tag-badge"><span class="tag-dot tag-dot-purple" aria-hidden="true"></span>{t}</span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   </section>
 
   <!-- ============================================================ -->

--- a/src/pages/horizon.astro
+++ b/src/pages/horizon.astro
@@ -1,0 +1,449 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+// Load all five horizon lane collections.
+const pastEntries = await getCollection('horizonPast');
+const nowEntries = await getCollection('horizonNow');
+const nextEntries = await getCollection('horizonNext');
+const debateEntries = await getCollection('horizonDebates');
+const scenarioEntries = await getCollection('horizonScenarios');
+
+// Sort Now by date descending so the most recent signal lands at the top.
+const sortedNow = [...nowEntries].sort((a, b) =>
+  b.data.date.localeCompare(a.data.date),
+);
+
+// Sort Past by date descending and group by year for the timeline.
+const sortedPast = [...pastEntries].sort((a, b) =>
+  b.data.date.localeCompare(a.data.date),
+);
+const pastByYear: Record<string, typeof sortedPast> = {};
+for (const entry of sortedPast) {
+  const year = entry.data.date.slice(0, 4);
+  if (!pastByYear[year]) pastByYear[year] = [];
+  pastByYear[year].push(entry);
+}
+const pastYears = Object.keys(pastByYear).sort((a, b) => b.localeCompare(a));
+
+// Confidence -> palette accent name. Used for borders, glow classes,
+// and the small confidence badge on each card.
+function confidenceAccent(c: string): 'green' | 'cyan' | 'amber' | 'purple' {
+  switch (c) {
+    case 'confirmed':
+      return 'green';
+    case 'emerging':
+      return 'cyan';
+    case 'contested':
+      return 'amber';
+    case 'speculative':
+      return 'purple';
+    default:
+      return 'cyan';
+  }
+}
+
+// Computed stats for the "Where are we now?" snapshot card. Recomputed at
+// build time so the snapshot stays in sync with the data without anyone
+// hand-editing copy each time the bot proposes a new entry.
+const nowConfidenceCounts = sortedNow.reduce(
+  (acc, e) => {
+    acc[e.data.confidence] = (acc[e.data.confidence] || 0) + 1;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+const nowSignalCounts = sortedNow.reduce(
+  (acc, e) => {
+    acc[e.data.signal_type] = (acc[e.data.signal_type] || 0) + 1;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+const nowThemeCounts = sortedNow.reduce(
+  (acc, e) => {
+    for (const t of e.data.themes) {
+      acc[t] = (acc[t] || 0) + 1;
+    }
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+const topThemes = Object.entries(nowThemeCounts)
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 3)
+  .map(([t]) => t);
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00Z');
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function formatYear(dateStr: string): string {
+  return dateStr.slice(0, 4);
+}
+---
+
+<BaseLayout
+  title="Horizon Map"
+  description="A living map of what has happened in AI, what is changing now, and what credible futures may come next."
+>
+  <!-- ============================================================ -->
+  <!-- HERO                                                          -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 pt-16 pb-8">
+    <header class="mb-10">
+      <a
+        href="/"
+        class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block"
+        >&larr; home</a
+      >
+      <h1
+        class="font-mono text-4xl md:text-5xl font-bold text-text-bright glow-cyan"
+      >
+        AI Horizon Map
+      </h1>
+      <p class="text-text-muted mt-3 text-lg max-w-3xl">
+        A living map of what has happened, what is changing now, and what
+        credible futures may come next.
+      </p>
+    </header>
+
+    <!-- Horizon band: past behind, now in middle (highlighted), next ahead. -->
+    <div class="relative mb-4">
+      <svg
+        viewBox="0 0 1000 100"
+        class="w-full h-auto"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <defs>
+          <linearGradient id="horizon-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stop-color="rgba(155, 122, 204, 0.18)" />
+            <stop offset="35%" stop-color="rgba(78, 203, 143, 0.10)" />
+            <stop offset="50%" stop-color="rgba(78, 203, 143, 0.30)" />
+            <stop offset="65%" stop-color="rgba(78, 203, 143, 0.10)" />
+            <stop offset="100%" stop-color="rgba(90, 184, 212, 0.18)" />
+          </linearGradient>
+        </defs>
+        <rect
+          x="0"
+          y="20"
+          width="1000"
+          height="60"
+          fill="url(#horizon-gradient)"
+          rx="6"
+        />
+        <line
+          x1="0"
+          y1="50"
+          x2="1000"
+          y2="50"
+          stroke="rgba(255, 255, 255, 0.08)"
+          stroke-width="1"
+        />
+      </svg>
+      <div class="absolute inset-0 flex justify-between items-center px-8">
+        <span
+          class="font-mono text-xs text-neon-purple/80 uppercase tracking-widest"
+          >Past</span
+        >
+        <span
+          class="font-mono text-xs text-neon-green uppercase tracking-widest glow-green"
+          >Now</span
+        >
+        <span
+          class="font-mono text-xs text-neon-cyan/80 uppercase tracking-widest"
+          >Next</span
+        >
+      </div>
+    </div>
+
+    <p class="font-mono text-xs text-text-muted/60 text-center">
+      {sortedPast.length} past turning points · {sortedNow.length} now signals · {nextEntries.length} next forecasts
+    </p>
+  </section>
+
+  <div class="glow-divider mb-12 max-w-5xl mx-auto" style="--divider-color: rgba(90, 184, 212, 0.15)"></div>
+
+  <!-- ============================================================ -->
+  <!-- NOW SNAPSHOT                                                  -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-12">
+    <div class="relative glass-card rounded-xl p-6 card-glow-cyan card-lift">
+      <h2
+        class="font-mono text-xs text-neon-cyan uppercase tracking-widest mb-4"
+      >
+        Where are we now?
+      </h2>
+      <div
+        class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-2 text-sm font-mono text-text-muted"
+      >
+        <div>
+          <span class="text-text-bright text-base">{sortedNow.length}</span> patterns tracked across the field
+        </div>
+        <div>
+          <span class="text-neon-green">{nowConfidenceCounts.confirmed || 0} confirmed</span>,
+          <span class="text-neon-cyan">{nowConfidenceCounts.emerging || 0} emerging</span>
+        </div>
+        <div>
+          <span class="text-text-bright text-base">{nowSignalCounts.inflection || 0}</span> inflections,
+          <span class="text-text-bright text-base">{nowSignalCounts.trend || 0}</span> trends
+        </div>
+        <div>
+          Top themes: <span class="text-text-bright">{topThemes.join(', ')}</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- NOW LANE                                                      -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-cyan">
+        Now
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        what is changing
+      </span>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+      {sortedNow.map((entry, i) => {
+        const accent = confidenceAccent(entry.data.confidence);
+        return (
+          <article
+            class={`relative glass-card rounded-xl p-6 card-glow-${accent} card-lift animate-stagger`}
+            style={`--stagger-index: ${i}`}
+          >
+            <div class="flex items-start justify-between gap-4 mb-3">
+              <h3
+                class={`font-mono text-base md:text-lg font-bold text-text-bright glow-${accent} leading-snug`}
+              >
+                {entry.data.title}
+              </h3>
+              <span
+                class={`shrink-0 font-mono text-[10px] px-2 py-1 rounded uppercase tracking-wider tag-dot tag-dot-${accent} bg-surface-light text-text-muted`}
+                style="display: inline-flex; align-items: center; gap: 0.4rem; width: auto; height: auto; box-shadow: none;"
+              >
+                <span class={`tag-dot tag-dot-${accent}`} aria-hidden="true"></span>
+                {entry.data.confidence}
+              </span>
+            </div>
+
+            <div class="flex flex-wrap gap-1.5 mb-4">
+              {entry.data.themes.map((t) => (
+                <span class="tag-badge"><span class="tag-dot tag-dot-cyan" aria-hidden="true"></span>{t}</span>
+              ))}
+            </div>
+
+            <p class="text-sm text-text-muted leading-relaxed mb-4">
+              {entry.data.why_it_matters}
+            </p>
+
+            {entry.data.implication && (
+              <div class="border-l-2 border-l-neon-cyan/30 pl-3 mb-4">
+                <p class="text-xs text-text-primary italic leading-relaxed">
+                  {entry.data.implication}
+                </p>
+              </div>
+            )}
+
+            <div class="flex items-center justify-between font-mono text-[11px] text-text-muted/70 pt-3 border-t border-surface-light/50">
+              <span>{formatDate(entry.data.date)}</span>
+              {entry.data.evidence && entry.data.evidence.length > 0 && (
+                <span>
+                  {entry.data.evidence.length} {entry.data.evidence.length === 1 ? 'source' : 'sources'}
+                </span>
+              )}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- PAST LANE                                                     -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-purple">
+        Past
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        what mattered, and when
+      </span>
+    </div>
+
+    <div class="space-y-10">
+      {pastYears.map((year) => (
+        <div>
+          <h3 class="font-mono text-sm text-neon-purple/80 uppercase tracking-widest mb-4 sticky top-0">
+            {year}
+          </h3>
+          <div class="space-y-4">
+            {pastByYear[year].map((entry) => (
+              <article class="glass-card rounded-lg p-5 card-glow-purple card-lift">
+                <div class="flex items-baseline justify-between gap-4 mb-2">
+                  <h4 class="font-mono text-base text-text-bright font-semibold">
+                    {entry.data.title}
+                  </h4>
+                  <span class="shrink-0 font-mono text-[11px] text-text-muted/70">
+                    {formatDate(entry.data.date)}
+                  </span>
+                </div>
+                <p class="text-sm text-text-muted leading-relaxed mb-3">
+                  {entry.data.why_it_matters}
+                </p>
+                <div class="flex flex-wrap gap-1.5">
+                  {entry.data.themes.map((t) => (
+                    <span class="tag-badge"><span class="tag-dot tag-dot-purple" aria-hidden="true"></span>{t}</span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- NEXT LANE                                                     -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-cyan">
+        Next
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        what credible futures may come
+      </span>
+    </div>
+
+    {nextEntries.length === 0 ? (
+      <div class="bg-surface border border-dashed border-surface-light rounded-lg p-8 text-center">
+        <p class="font-mono text-sm text-text-muted/80">
+          <span class="text-neon-cyan">●</span> forecasts coming soon
+        </p>
+        <p class="text-xs text-text-muted/60 mt-2">
+          The Next lane will hold 12-15 forecasts with confidence labels and freshness timestamps. Currently being seeded.
+        </p>
+      </div>
+    ) : (
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        {/* Future renderer for Next entries */}
+      </div>
+    )}
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- COMPARE VIEW                                                  -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-amber">
+        Compare View
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        three credible futures, side by side
+      </span>
+    </div>
+
+    {scenarioEntries.length === 0 ? (
+      <div class="bg-surface border border-dashed border-surface-light rounded-lg p-8 text-center">
+        <p class="font-mono text-sm text-text-muted/80">
+          <span class="text-neon-amber">●</span> scenario triplets coming soon
+        </p>
+        <p class="text-xs text-text-muted/60 mt-2">
+          Pick a topic, see optimistic / pragmatic / sceptical futures with timeframes, assumptions, blockers, and implications. The most-citeable module on the page, by design.
+        </p>
+      </div>
+    ) : (
+      <div>{/* Future renderer for scenarios */}</div>
+    )}
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- DEBATE ZONE                                                   -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-amber">
+        Debate Zone
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        where smart people genuinely disagree
+      </span>
+    </div>
+
+    {debateEntries.length === 0 ? (
+      <div class="bg-surface border border-dashed border-surface-light rounded-lg p-8 text-center">
+        <p class="font-mono text-sm text-text-muted/80">
+          <span class="text-neon-amber">●</span> debates coming soon
+        </p>
+        <p class="text-xs text-text-muted/60 mt-2">
+          Hand-curated for/against pairs with supporting evidence on both sides. Not "who is right" but "where the field is split".
+        </p>
+      </div>
+    ) : (
+      <div>{/* Future renderer for debates */}</div>
+    )}
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- WEEKLY SHIFT LOG                                              -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-16">
+    <div class="flex items-baseline justify-between mb-6">
+      <h2 class="font-mono text-2xl font-bold text-text-bright glow-green">
+        Weekly Shift Log
+      </h2>
+      <span class="font-mono text-xs text-text-muted/70 uppercase tracking-widest">
+        what changed, last 7 days
+      </span>
+    </div>
+
+    <div class="bg-surface border border-dashed border-surface-light rounded-lg p-8 text-center">
+      <p class="font-mono text-sm text-text-muted/80">
+        <span class="text-neon-green">●</span> shift log coming soon
+      </p>
+      <p class="text-xs text-text-muted/60 mt-2">
+        Auto-derived from <code class="text-neon-green/80">git log -- src/data/horizon/</code> at build time. Will populate once the horizon bot starts proposing changes.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <!-- FOOTER CTA                                                    -->
+  <!-- ============================================================ -->
+  <section class="max-w-5xl mx-auto px-6 mb-20">
+    <div class="glow-divider mb-10" style="--divider-color: rgba(255, 255, 255, 0.08)"></div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="glass-card rounded-xl p-6 card-glow-cyan">
+        <h3 class="font-mono text-sm text-neon-cyan uppercase tracking-widest mb-2">
+          Track a theme
+        </h3>
+        <p class="text-sm text-text-muted leading-relaxed">
+          Filter the map by what you actually care about. Theme filters and URL persistence land in the next iteration.
+        </p>
+      </div>
+      <div class="glass-card rounded-xl p-6 card-glow-purple">
+        <h3 class="font-mono text-sm text-neon-purple uppercase tracking-widest mb-2">
+          Explore the machinery
+        </h3>
+        <p class="text-sm text-text-muted leading-relaxed">
+          The horizon map is built and maintained by the same six bots that run the rest of the site.
+          <a href="/pipeline" class="text-neon-cyan hover:underline">See how it works</a>.
+        </p>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/horizon.astro
+++ b/src/pages/horizon.astro
@@ -229,8 +229,7 @@ function formatYear(dateStr: string): string {
                 {entry.data.title}
               </h3>
               <span
-                class={`shrink-0 font-mono text-[10px] px-2 py-1 rounded uppercase tracking-wider tag-dot tag-dot-${accent} bg-surface-light text-text-muted`}
-                style="display: inline-flex; align-items: center; gap: 0.4rem; width: auto; height: auto; box-shadow: none;"
+                class="shrink-0 inline-flex items-center gap-1.5 font-mono text-[10px] px-2 py-1 rounded uppercase tracking-wider bg-surface-light text-text-muted"
               >
                 <span class={`tag-dot tag-dot-${accent}`} aria-hidden="true"></span>
                 {entry.data.confidence}


### PR DESCRIPTION
Replaces #93 (auto-closed when its base branch \`horizon-schema\` was deleted by the squash-merge of #91). Same content, retargeted to main.

## Summary

Seeds the Now lane with 6 current AI patterns and ships the static renderer at \`/horizon\`. Includes the visual fixes from the original review (confidence badge CSS readability, section reorder so the page flows forward).

## Test plan

- [ ] \`npm run build\` — exits 0, page count includes \`/horizon\`
- [ ] Visit \`/horizon\` — Hero, Now Snapshot, Now lane, Compare View (empty state), Debate Zone (empty state), Past lane, Weekly Shift Log all render
- [ ] Confidence badges are readable text, not solid colored ovals
- [ ] Section order: Hero → Now Snapshot → Now → Next (empty) → Compare View (empty) → Debate Zone (empty) → Past → Weekly Shift Log

🤖 Generated with [Claude Code](https://claude.com/claude-code)