### PR TITLE
Surface horizon in nav and hero copy

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 const navLinks = [
   { label: 'news', href: '/news-and-updates', title: 'Latest AI news and updates' },
+  { label: 'horizon', href: '/horizon', title: 'A living map of past, present, and credible future AI' },
   { label: 'thoughts', href: '/thoughts', title: 'Observations and opinions' },
   { label: 'radar', href: '/radar', title: 'AI tools and launches worth knowing about' },
   { label: 'tools', href: '/tools', title: 'Interactive tools and write-ups' },

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -16,13 +16,15 @@
     </h1>
 
     <p class="text-xl md:text-2xl text-text-bright max-w-2xl leading-relaxed font-medium">
-      This site wrote itself this morning. Here's how.
+      This site wrote itself this morning. Mostly.
     </p>
 
     <p class="text-base text-text-muted max-w-2xl leading-relaxed mt-4">
-      Six bots. Five RSS feeds. One pipeline. Every piece of content on this site
-      was generated, reviewed, and published by automated AI infrastructure.
-      The site is the product. The content is the output. The real story is the machinery.
+      Six bots. Five RSS feeds. One pipeline. Almost everything you see was generated,
+      reviewed, and published by automated AI infrastructure. The Horizon Map is the
+      exception: a hand-curated living chart of where AI has been, where it is, and
+      where it's credibly going next. The site is the product. The content is the
+      output. The real story is the machinery.
     </p>
   </div>
 
@@ -35,6 +37,13 @@
     >
       <span>&gt;</span>
       <span>news & updates</span>
+    </a>
+    <a
+      href="/horizon"
+      class="inline-flex items-center gap-2 px-5 py-2.5 bg-surface border border-neon-amber/30 rounded-lg font-mono text-sm text-neon-amber hover:bg-neon-amber/10 hover:border-neon-amber/60 transition-all"
+    >
+      <span>&gt;</span>
+      <span>horizon</span>
     </a>
     <a
       href="/thoughts"


### PR DESCRIPTION
## Summary

Two small changes to make the new \`/horizon\` page discoverable from the homepage:

1. **Header nav** — adds \`horizon\` between \`news\` and \`thoughts\`
2. **Hero CTA grid** — adds an amber \`> horizon\` button between \`news & updates\` and \`thoughts\`
3. **Hero copy** — updates the description to acknowledge that the site is no longer purely bot-generated. The Horizon Map is hand-curated, so the previous "every piece of content was generated by automated AI infrastructure" was technically false. New copy:

   > This site wrote itself this morning. **Mostly.**
   >
   > Six bots. Five RSS feeds. One pipeline. Almost everything you see was generated, reviewed, and published by automated AI infrastructure. **The Horizon Map is the exception: a hand-curated living chart of where AI has been, where it is, and where it's credibly going next.** The site is the product. The content is the output. The real story is the machinery.

## Test plan

- [ ] \`npm run build\` exits 0
- [ ] Header nav order on every page: news · horizon · thoughts · radar · tools · pipeline · play
- [ ] Homepage Hero copy reads "Mostly." and mentions the Horizon Map
- [ ] CTA grid shows the amber horizon button between news and thoughts
- [ ] Click horizon from nav and from CTA — both land at \`/horizon\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)