### PR TITLE
fix(bots): swap pipeline_log before commit (closes #97)

### DIFF
--- a/bot/ai_news_digest.py
+++ b/bot/ai_news_digest.py
@@ -228,15 +228,17 @@ def main():
         # Sonnet pricing: $3/M input, $15/M output
         cost = (usage.input_tokens * 3 + usage.output_tokens * 15) / 1_000_000
 
-        print("Saving and pushing...")
-        save_and_push(content, entries, history)
-
+        # Log BEFORE commit so the runs.json entry lands in the same commit
+        # as this bot's data changes, not the next bot's commit (issue #97).
         slug_date = date.today().strftime("%Y-%m-%d")
         log_run("news_bot", status="success", duration_s=_time.time() - t0,
                 feeds_scanned=len(FEEDS), items_found=len(entries), items_published=1,
                 model="claude-sonnet-4-20250514", cost_usd=cost,
                 input_tokens=usage.input_tokens, output_tokens=usage.output_tokens,
                 output_files=[f"src/content/news-and-updates/{slug_date}-ai-digest.md"])
+
+        print("Saving and pushing...")
+        save_and_push(content, entries, history)
 
         print("Done.")
         ping_healthcheck()

--- a/bot/ai_thoughts_bot.py
+++ b/bot/ai_thoughts_bot.py
@@ -254,9 +254,8 @@ def main():
         content, usage = result
         cost = (usage.input_tokens * 3 + usage.output_tokens * 15) / 1_000_000
 
-        print("Saving and pushing...")
-        save_and_push(content, history, push=not args.no_push)
-
+        # Log BEFORE commit so the runs.json entry lands in the same commit
+        # as this bot's data changes, not the next bot's commit (issue #97).
         slug_date = os.environ.get("THOUGHT_DATE", date.today().isoformat())
         title = extract_title(content)
         slug = slugify(title)
@@ -265,6 +264,9 @@ def main():
                 model="claude-sonnet-4-20250514", cost_usd=cost,
                 input_tokens=usage.input_tokens, output_tokens=usage.output_tokens,
                 output_files=[f"src/content/thoughts/{slug_date}-{slug}.md"])
+
+        print("Saving and pushing...")
+        save_and_push(content, history, push=not args.no_push)
 
         print("Done.")
         ping_healthcheck()

--- a/bot/prompt_library_bot.py
+++ b/bot/prompt_library_bot.py
@@ -320,14 +320,16 @@ def main():
             cost = (usage.input_tokens * 3 + usage.output_tokens * 15) / 1_000_000
             in_tok, out_tok = usage.input_tokens, usage.output_tokens
 
-        print(f"Generated {len(prompts)} prompt(s). Saving...")
-        save_and_push(prompts, history, push=not args.no_push)
-
+        # Log BEFORE commit so the runs.json entry lands in the same commit
+        # as this bot's data changes, not the next bot's commit (issue #97).
         log_run("prompt_bot", status="success", duration_s=_time.time() - t0,
                 feeds_scanned=len(FEEDS), items_found=len(entries),
                 items_published=len(prompts),
                 model="claude-sonnet-4-20250514", cost_usd=cost,
                 input_tokens=in_tok, output_tokens=out_tok)
+
+        print(f"Generated {len(prompts)} prompt(s). Saving...")
+        save_and_push(prompts, history, push=not args.no_push)
 
         print("Done.")
         ping_healthcheck()

--- a/bot/radar_bot.py
+++ b/bot/radar_bot.py
@@ -422,10 +422,10 @@ def main():
         if not entries and not hn_entries:
             print("No entries found — writing empty state.")
             empty_data = {"date": date.today().isoformat(), "featured": [], "picks": []}
-            save_and_push(empty_data, history)
             _log_run("radar_bot", status="success", duration_s=time.time() - t0,
                      feeds_scanned=len(FEEDS) + len(HN_SEARCH_TERMS),
                      items_found=0, items_published=0)
+            save_and_push(empty_data, history)
             ping_healthcheck()
             sys.exit(0)
 
@@ -435,11 +435,11 @@ def main():
         if not result:
             print("Claude returned 0 picks — writing empty state.")
             empty_data = {"date": date.today().isoformat(), "featured": [], "picks": []}
-            save_and_push(empty_data, history)
             _log_run("radar_bot", status="success", duration_s=time.time() - t0,
                      feeds_scanned=len(FEEDS) + len(HN_SEARCH_TERMS),
                      items_found=total_found, items_published=0,
                      model="claude-sonnet-4-20250514")
+            save_and_push(empty_data, history)
             ping_healthcheck()
             sys.exit(0)
 
@@ -460,9 +460,8 @@ def main():
             "hn_top5": radar_data.get("hn_top5", []),
         }
 
-        print("Saving and pushing...")
-        save_and_push(site_data, history)
-
+        # Log BEFORE commit so the runs.json entry lands in the same commit
+        # as this bot's data changes, not the next bot's commit (issue #97).
         today = date.today().isoformat()
         _log_run("radar_bot", status="success", duration_s=time.time() - t0,
                  feeds_scanned=len(FEEDS) + len(HN_SEARCH_TERMS),
@@ -470,6 +469,9 @@ def main():
                  model="claude-sonnet-4-20250514", cost_usd=cost,
                  input_tokens=usage.input_tokens, output_tokens=usage.output_tokens,
                  output_files=[f"src/data/radar/{today}.json"])
+
+        print("Saving and pushing...")
+        save_and_push(site_data, history)
 
         print("Done.")
         ping_healthcheck()

--- a/bot/tool_of_the_week.py
+++ b/bot/tool_of_the_week.py
@@ -239,14 +239,16 @@ def main():
             cost = (usage.input_tokens * 3 + usage.output_tokens * 15) / 1_000_000
             in_tok, out_tok = usage.input_tokens, usage.output_tokens
 
-        print("Committing and pushing...")
-        git_commit_and_push(filename)
-
+        # Log BEFORE commit so the runs.json entry lands in the same commit
+        # as this bot's data changes, not the next bot's commit (issue #97).
         log_run("tool_bot", status="success", duration_s=_time.time() - t0,
                 feeds_scanned=len(FEEDS), items_found=len(entries), items_published=1,
                 model="claude-sonnet-4-20250514", cost_usd=cost,
                 input_tokens=in_tok, output_tokens=out_tok,
                 output_files=[f"src/content/tools/{filename}"])
+
+        print("Committing and pushing...")
+        git_commit_and_push(filename)
 
         print("Done.")
         ping_healthcheck()


### PR DESCRIPTION
## Summary
Closes #97. Every bot's commit contained the PREVIOUS bot's runs.json entry because \`log_run()\` ran after \`save_and_push()\`. radar_bot (last in the daily sequence) had its entry stranded as drift every day.

One-swap-per-bot fix: call \`log_run()\` BEFORE the commit step so the runs.json entry lands in the same commit as that bot's data changes. Applied to radar, news, thoughts, prompt, tool. horizon_bot and model_bot already had the right shape from earlier fixes.

Every bot already stages \`src/data/pipeline/runs.json\` in its \`git add\` — this PR only changes *when* the append happens, not *what* gets committed.

## Test plan
- [x] \`python3 -m py_compile\` on all 5 modified files.
- [ ] Tomorrow's run sequence (news 07:00 → thoughts 08:00 → radar 09:30 → horizon 10:00 UTC, plus model 04:00): confirm each bot's commit contains its OWN runs.json entry, not the previous bot's. radar_bot's entry should no longer sit stranded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)