### PR TITLE
fix(glossary): audit corrections after TTT verification

### DIFF
--- a/src/content/glossary/continual-learning.md
+++ b/src/content/glossary/continual-learning.md
@@ -14,7 +14,7 @@ related:
 draft: false
 ---
 
-Continual learning is the practice of training AI models to acquire new tasks or information over time without degrading performance on what they already know, a failure mode called catastrophic forgetting. Standard fine-tuning tends to overwrite existing capabilities when trained on new data. Continual learning techniques such as sparse updates, memory replay, and skill isolation let models accumulate knowledge incrementally instead. A March 2026 paper introduced a Continual Meta-Learning Framework for LLM agents that jointly evolves policies and reusable skills with minimal downtime between updates.
+Continual learning is the practice of training AI models to acquire new tasks or information over time without degrading performance on what they already know, a failure mode called catastrophic forgetting. Standard fine-tuning tends to overwrite existing capabilities when trained on new data. Continual learning techniques such as sparse updates, memory replay, and skill isolation let models accumulate knowledge incrementally instead. Recent research on continual meta-learning for LLM agents explores jointly evolving policies and reusable skills with minimal downtime between updates.
 
 In practice, a customer support agent built with continual learning can be updated with new product knowledge each week without losing its grasp of older product lines or general language ability.
 

--- a/src/content/glossary/sparse-attention.md
+++ b/src/content/glossary/sparse-attention.md
@@ -14,7 +14,7 @@ related:
 draft: false
 ---
 
-Sparse attention is a technique for making transformer models more efficient by having each token attend only to a relevant subset of other tokens, rather than every token in the sequence. Standard full attention scales quadratically with context length, which becomes prohibitively expensive as documents grow. Sparse attention achieves near-linear scaling instead. A March 2026 paper demonstrated end-to-end processing at 100 million tokens using this approach.
+Sparse attention is a technique for making transformer models more efficient by having each token attend only to a relevant subset of other tokens, rather than every token in the sequence. Standard full attention scales quadratically with context length, which becomes prohibitively expensive as documents grow. Sparse attention achieves near-linear scaling instead. [A March 2026 paper](https://arxiv.org/abs/2603.23516) demonstrated end-to-end processing at 100 million tokens using this approach.
 
 In practice, sparse attention allows a model to summarise or reason over an entire book, codebase, or legal document in a single pass without the cost blowing out proportionally.
 


### PR DESCRIPTION
## Summary
Two corrections caught while verifying PR #87's NVIDIA TTT link. Same bot (commit `2522b92`) wrote all five glossary entries in one shot and got factual details wrong in two of them.

- **sparse-attention**: link the "March 2026 paper" citation to the actual [MSA paper](https://arxiv.org/abs/2603.23516) (submitted March 6, 2026). Same enhancement pattern as the TTT glossary link.
- **continual-learning**: soften *"A March 2026 paper introduced a Continual Meta-Learning Framework for LLM agents that jointly evolves policies and reusable skills"* — no paper with that specific name and attributes could be found via web search. Replaced with a defensible framing of the research direction, no citation.

## Verification done
- WebFetch against arxiv confirms MSA paper (2603.23516) exists, covers 100M-token sparse attention, published March 2026 ✓
- WebSearch for "Continual Meta-Learning Framework for LLM agents" March 2026 returns no matching paper — closest hits are ReMA (March 2025, different focus) and the TPAMI 2026 lifelong-learning survey (not a framework paper)
- The other three entries from the same commit (TTT, MCP, LangGraph) were verified and are factually fine (TTT date was fixed in PR #87)

## Test plan
- [x] `npm run build` passes (543 pages)
- [x] `node scripts/validate-horizon-refs.mjs` passes (52 entries, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)