### PR TITLE
feat(horizon): Five Horizons — standalone strip at /horizon/five

### DIFF
--- a/bot/horizon_bot.py
+++ b/bot/horizon_bot.py
@@ -460,6 +460,169 @@ def build_shifts_log() -> list[dict]:
     return shifts
 
 
+STANCES = ("optimistic", "pragmatic", "sceptical")
+GIT_SHOW_TIMEOUT_S = 5
+
+
+def parse_scenario_diff(sha: str) -> list[dict] | None:
+    """Compare scenarios.json at `sha` vs its parent; emit year/band deltas.
+
+    Returns a list of change records. Empty list means "no meaningful drift"
+    (e.g., whitespace-only commit). None means "couldn't parse" — the caller
+    should fall back to emitting an unenriched shift entry.
+
+    Failure modes handled (plan 2026-04-22):
+      * file absent at parent (first commit touching scenarios.json)
+      * malformed JSON on either side
+      * git show timeout
+      * merge commits (first parent used via ``sha^`` which git resolves to -p1)
+      * whitespace-only edits (deep-equal short-circuit)
+      * renamed horizon ids (treated as remove + add, emitted as stance-level
+        removes + adds)
+      * stance block added or removed (emitted with stance_added/removed flags)
+      * indefinite year (delta_months null, band_change may still fire)
+    """
+    try:
+        after_raw = subprocess.run(
+            ["git", "show", f"{sha}:src/data/horizon/scenarios.json"],
+            capture_output=True, text=True, check=True,
+            timeout=GIT_SHOW_TIMEOUT_S,
+        ).stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print(f"[horizon_bot] parse_scenario_diff: git show after failed for {sha}: {e}")
+        return None
+
+    try:
+        before_raw = subprocess.run(
+            ["git", "show", f"{sha}^:src/data/horizon/scenarios.json"],
+            capture_output=True, text=True, check=True,
+            timeout=GIT_SHOW_TIMEOUT_S,
+        ).stdout
+    except subprocess.CalledProcessError:
+        # No parent, or file didn't exist at parent. No drift to compute.
+        return []
+    except subprocess.TimeoutExpired:
+        return None
+
+    try:
+        after_json = json.loads(after_raw)
+        before_json = json.loads(before_raw)
+    except json.JSONDecodeError as e:
+        print(f"[horizon_bot] parse_scenario_diff: JSON decode failed for {sha}: {e}")
+        return None
+
+    # Whitespace-only / no functional change.
+    if before_json == after_json:
+        return []
+
+    if not isinstance(before_json, list) or not isinstance(after_json, list):
+        print(f"[horizon_bot] parse_scenario_diff: unexpected top-level shape for {sha}")
+        return None
+
+    before_map = {s["id"]: s for s in before_json if isinstance(s, dict) and "id" in s}
+    after_map = {s["id"]: s for s in after_json if isinstance(s, dict) and "id" in s}
+
+    changes: list[dict] = []
+    all_ids = set(before_map) | set(after_map)
+    for scenario_id in sorted(all_ids):
+        before_s = before_map.get(scenario_id)
+        after_s = after_map.get(scenario_id)
+        if before_s is None or after_s is None:
+            # Whole scenario added/removed — treat as structural, not drift.
+            continue
+        for stance in STANCES:
+            try:
+                before_stance = before_s.get(stance)
+                after_stance = after_s.get(stance)
+            except AttributeError:
+                continue
+            if before_stance is None and after_stance is None:
+                continue
+            if before_stance is None:
+                changes.append({
+                    "horizon": scenario_id,
+                    "stance": stance,
+                    "from": None,
+                    "to": after_stance.get("year") if isinstance(after_stance, dict) else None,
+                    "delta_months": None,
+                    "stance_added": True,
+                })
+                continue
+            if after_stance is None:
+                changes.append({
+                    "horizon": scenario_id,
+                    "stance": stance,
+                    "from": before_stance.get("year") if isinstance(before_stance, dict) else None,
+                    "to": None,
+                    "delta_months": None,
+                    "stance_removed": True,
+                })
+                continue
+
+            before_year = before_stance.get("year") if isinstance(before_stance, dict) else None
+            before_band = before_stance.get("band") if isinstance(before_stance, dict) else None
+            after_year = after_stance.get("year") if isinstance(after_stance, dict) else None
+            after_band = after_stance.get("band") if isinstance(after_stance, dict) else None
+
+            year_changed = before_year != after_year
+            band_changed = before_band != after_band
+            if not year_changed and not band_changed:
+                continue
+
+            record: dict = {
+                "horizon": scenario_id,
+                "stance": stance,
+                "from": before_year,
+                "to": after_year,
+            }
+            if isinstance(before_year, int) and isinstance(after_year, int):
+                record["delta_months"] = (after_year - before_year) * 12
+            else:
+                record["delta_months"] = None
+            if band_changed:
+                record["band_change"] = {"from": before_band, "to": after_band}
+            changes.append(record)
+
+    return changes
+
+
+def enrich_scenario_shifts(shifts: list[dict]) -> tuple[list[dict], int]:
+    """Second pass over the shift log. For each entry where lane == 'scenarios',
+    compute a `changes` array via parse_scenario_diff.
+
+    Returns the enriched list plus a count of successfully parsed scenario
+    commits (for pipeline_log observability)."""
+    parsed_count = 0
+    enriched: list[dict] = []
+    seen_shas: set[str] = set()
+    for s in shifts:
+        if s.get("lane") != "scenarios":
+            enriched.append(s)
+            continue
+        # A single commit may appear once per lane — but we diff the scenarios
+        # file at that sha exactly once.
+        sha = s.get("sha")
+        if sha and sha in seen_shas:
+            enriched.append(s)
+            continue
+        if sha:
+            seen_shas.add(sha)
+        changes = parse_scenario_diff(sha) if sha else None
+        if changes is None:
+            # Couldn't parse; emit unenriched entry so shift log still renders.
+            enriched.append(s)
+            continue
+        parsed_count += 1
+        if changes:
+            enriched.append({**s, "changes": changes})
+        else:
+            # No drift detected (whitespace-only, structural-only, etc.); still
+            # emit the shift without a changes array so the renderer falls back
+            # to the commit-subject line.
+            enriched.append(s)
+    return enriched, parsed_count
+
+
 def write_shifts_log(shifts: list[dict]) -> bool:
     """Write shifts.json only if content changed. Returns True if written."""
     existing = _read_json(SHIFTS_FILE, None)
@@ -735,11 +898,14 @@ def main():
         # Proposal PR (Now entries only for now; Next/Past still staging-only)
         pr_url = create_proposal_pr(now_proposals)
 
-        # Shifts.json (committed if changed)
+        # Shifts.json (committed if changed). Second pass enriches scenario-lane
+        # entries with year/band delta arrays so /horizon/five can narrate drift.
         shifts = build_shifts_log()
+        shifts, scenario_changes_parsed = enrich_scenario_shifts(shifts)
         shifts_changed = write_shifts_log(shifts)
         print(f"[horizon_bot] Shifts: {len(shifts)} entries, "
-              f"{'changed' if shifts_changed else 'unchanged'}")
+              f"{'changed' if shifts_changed else 'unchanged'}, "
+              f"{scenario_changes_parsed} scenario commit(s) parsed")
 
         # Discord ping (opt-in)
         post_to_discord(len(now_proposals), len(next_flags), len(past_candidates),

--- a/scripts/validate-horizon-refs.mjs
+++ b/scripts/validate-horizon-refs.mjs
@@ -153,6 +153,84 @@ for (const s of scenarios) {
   }
 }
 
+// Five Horizons additions (2026-04-22).
+// Banded-axis boundaries are duplicated from src/lib/horizon-axis.ts because
+// this .mjs validator cannot import TypeScript. Keep in sync when the chart
+// thresholds change.
+const BAND_NEAR_MAX_DELTA = 4;   // 0-4 years out of currentYear
+const BAND_MID_MAX_DELTA = 9;    // 5-9 years out
+const BAND_FAR_MAX_DELTA = 19;   // 10-19 years out; 20+ is indefinite
+
+function yearToBand(year, currentYear) {
+  if (year == null) return 'indefinite';
+  const delta = year - currentYear;
+  if (delta <= BAND_NEAR_MAX_DELTA) return 'near';
+  if (delta <= BAND_MID_MAX_DELTA) return 'mid';
+  if (delta <= BAND_FAR_MAX_DELTA) return 'far';
+  return 'indefinite';
+}
+
+const CURRENT_YEAR = new Date().getUTCFullYear();
+for (const s of scenarios) {
+  // debate_ref must resolve to an existing debate id.
+  if (s.debate_ref) {
+    const debateIds = new Set(debates.map((d) => d.id));
+    if (!debateIds.has(s.debate_ref)) {
+      errors.push(`scenarios.json: "${s.id}" debate_ref -> unknown debate id "${s.debate_ref}"`);
+    }
+  }
+  // Band/year consistency (warning — bot drift without band update is expected).
+  for (const stance of ['optimistic', 'pragmatic', 'sceptical']) {
+    const entry = s[stance];
+    if (!entry || !entry.band) continue;
+    const { year, band } = entry;
+    if (band === 'indefinite' && year != null) {
+      warnings.push(
+        `scenarios.json: "${s.id}" ${stance} has band="indefinite" but year=${year} (year will be ignored at render)`,
+      );
+      continue;
+    }
+    if (band !== 'indefinite' && year != null) {
+      const derived = yearToBand(year, CURRENT_YEAR);
+      if (derived !== band) {
+        warnings.push(
+          `scenarios.json: "${s.id}" ${stance} band="${band}" does not match year-derived band="${derived}" (year=${year}, currentYear=${CURRENT_YEAR})`,
+        );
+      }
+    }
+  }
+}
+
+// shifts.json — optional `changes` array on scenarios-touching entries.
+// Emitted by bot/horizon_bot.py when a commit touches scenarios.json.
+let shifts = [];
+try {
+  shifts = readJson(join(HORIZON_DIR, 'shifts.json'));
+} catch {
+  // shifts.json may not exist in a minimal checkout; not an error.
+}
+const STANCE_SET = new Set(['optimistic', 'pragmatic', 'sceptical']);
+for (let i = 0; i < shifts.length; i++) {
+  const shift = shifts[i];
+  if (!shift.changes) continue;
+  if (!Array.isArray(shift.changes)) {
+    errors.push(`shifts.json[${i}]: changes must be an array`);
+    continue;
+  }
+  for (let j = 0; j < shift.changes.length; j++) {
+    const c = shift.changes[j];
+    if (typeof c.horizon !== 'string' || !c.horizon) {
+      errors.push(`shifts.json[${i}].changes[${j}]: missing or invalid horizon field`);
+    }
+    if (!STANCE_SET.has(c.stance)) {
+      errors.push(`shifts.json[${i}].changes[${j}]: stance must be one of ${[...STANCE_SET].join('|')}`);
+    }
+    if (c.delta_months != null && typeof c.delta_months !== 'number') {
+      errors.push(`shifts.json[${i}].changes[${j}]: delta_months must be number or null`);
+    }
+  }
+}
+
 // 6. Next-lane confidence freshness warning.
 const today = new Date();
 today.setUTCHours(0, 0, 0, 0);

--- a/src/components/HorizonStrip.tsx
+++ b/src/components/HorizonStrip.tsx
@@ -271,10 +271,10 @@ export default function HorizonStrip({
           })}
 
           {/* Year ticks along the axis */}
-          {axisYearTicks(axis).map(({ year, band }) => {
+          {axisYearTicks(axis).map(({ year, band, display }) => {
             const x = LABEL_COL_W + yearToX(year, band, axis);
             return (
-              <g key={`tick-${year}`}>
+              <g key={`tick-${band}-${year}`}>
                 <line
                   x1={x}
                   x2={x}
@@ -290,7 +290,7 @@ export default function HorizonStrip({
                   class="font-mono fill-text-muted"
                   style="font-size: 10px;"
                 >
-                  {year}
+                  {display ?? year}
                 </text>
               </g>
             );
@@ -715,13 +715,27 @@ function formatDelta(months: number): string {
   return `${years} yr ${sign}`;
 }
 
-function axisYearTicks(axis: typeof DEFAULT_AXIS_CONFIG) {
-  const ticks: { year: number; band: Band }[] = [];
-  for (let y = axis.nearRange[0]; y <= axis.nearRange[1]; y++) ticks.push({ year: y, band: 'near' });
-  for (let y = axis.midRange[0]; y <= axis.midRange[1]; y += 2) ticks.push({ year: y, band: 'mid' });
-  // Far zone gets just the endpoints
-  ticks.push({ year: axis.farRange[0], band: 'far' });
-  ticks.push({ year: Math.floor((axis.farRange[0] + axis.farRange[1]) / 2), band: 'far' });
-  ticks.push({ year: axis.farRange[1], band: 'far' });
+// Year-axis ticks. NEAR zone gets per-year precision (reader decision window).
+// MID/FAR zones collapse to a single band-centred label to avoid collisions
+// at zone boundaries (2030/2031 and 2035/2036 were overlapping at 10px font).
+function axisYearTicks(
+  axis: typeof DEFAULT_AXIS_CONFIG,
+): { year: number; band: Band; display?: string }[] {
+  const ticks: { year: number; band: Band; display?: string }[] = [];
+  for (let y = axis.nearRange[0]; y <= axis.nearRange[1]; y++) {
+    ticks.push({ year: y, band: 'near' });
+  }
+  const midCenter = Math.round((axis.midRange[0] + axis.midRange[1]) / 2);
+  ticks.push({
+    year: midCenter,
+    band: 'mid',
+    display: `${axis.midRange[0]}-${axis.midRange[1]}`,
+  });
+  const farCenter = Math.round((axis.farRange[0] + axis.farRange[1]) / 2);
+  ticks.push({
+    year: farCenter,
+    band: 'far',
+    display: `${axis.farRange[0]}+`,
+  });
   return ticks;
 }

--- a/src/components/HorizonStrip.tsx
+++ b/src/components/HorizonStrip.tsx
@@ -85,6 +85,17 @@ const ROW_ACCENT_CLASS: Record<ScenarioForStrip['accent'], string> = {
   red: 'text-neon-red',
 };
 
+// Short chart labels. The full scenario.topic would overflow the 240px label
+// column at 26px mono (SOFTWARE AUTOMATION = 324px, EDUCATION DISRUPTION = 341px).
+// Matches the terminology in the original Five Horizons ASCII mockup.
+const DISPLAY_LABEL: Record<string, string> = {
+  'AGI': 'AGI',
+  'Agentic Work': 'AGENTIC',
+  'Robotics': 'ROBOTS',
+  'Software Automation': 'SW AUTO',
+  'Education Disruption': 'EDUCATION',
+};
+
 interface Tooltip {
   kind: 'dot' | 'label';
   scenarioId: string;
@@ -377,7 +388,7 @@ export default function HorizonStrip({
                     class={`font-mono font-bold ${ROW_ACCENT_CLASS[s.accent]}`}
                     style="font-size: 26px; letter-spacing: 0.04em;"
                   >
-                    {s.topic.toUpperCase()}
+                    {(DISPLAY_LABEL[s.topic] ?? s.topic).toUpperCase()}
                   </text>
                   {s.contested && (
                     <text

--- a/src/components/HorizonStrip.tsx
+++ b/src/components/HorizonStrip.tsx
@@ -1,0 +1,716 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import type { JSX } from 'preact';
+import {
+  yearToX,
+  zoneStartX,
+  totalAxisWidth,
+  dotCollisionOffsets,
+  DEFAULT_AXIS_CONFIG,
+  yearToBand,
+} from '../lib/horizon-axis';
+import type { Band, Stance } from '../lib/horizon-axis';
+
+// Data shapes (mirrors content.config.ts scenarios schema for the runtime
+// island — Astro collections feed this via JSON-serialised props).
+interface ScenarioStance {
+  timeframe: string;
+  year?: number | null;
+  band?: Band;
+  assumptions: string;
+  blockers: string;
+  implication: string;
+}
+
+export interface ScenarioForStrip {
+  id: string;
+  topic: string;
+  themes: string[];
+  definition: string;
+  contested?: boolean;
+  debate_ref?: string;
+  accent: 'green' | 'cyan' | 'purple' | 'amber' | 'red';
+  optimistic: ScenarioStance;
+  pragmatic: ScenarioStance;
+  sceptical: ScenarioStance;
+}
+
+export interface EventMarker {
+  year: number;
+  label: string;
+}
+
+export interface ShiftChange {
+  horizon: string;
+  stance: Stance;
+  from?: number | null;
+  to?: number | null;
+  delta_months?: number | null;
+}
+
+interface Props {
+  scenarios: ScenarioForStrip[];
+  events: EventMarker[];
+  recentChanges: Record<string, ShiftChange[]>;
+  currentYear: number;
+}
+
+// Layout constants for the SVG. Chart gets a massive label column on the
+// left, then the banded axis to the right. Full-bleed on the page — this
+// component doesn't impose outer padding.
+const LABEL_COL_W = 240;
+const ROW_H = 90;
+const AXIS_H = 54;
+const HEADER_H = 28;
+const DOT_R = 9;
+const DOT_GHOST_R = 6;
+const ENVELOPE_OPACITY = 0.1;
+
+const STANCE_COLORS: Record<Stance, string> = {
+  optimistic: 'var(--color-neon-green, #4ecb8f)',
+  pragmatic: 'var(--color-neon-cyan, #5ab8d4)',
+  sceptical: 'var(--color-neon-red, #da5e74)',
+};
+
+const STANCE_LABEL: Record<Stance, string> = {
+  optimistic: 'optimistic',
+  pragmatic: 'pragmatic',
+  sceptical: 'sceptical',
+};
+
+const ROW_ACCENT_CLASS: Record<ScenarioForStrip['accent'], string> = {
+  green: 'text-neon-green',
+  cyan: 'text-neon-cyan',
+  purple: 'text-neon-purple',
+  amber: 'text-neon-amber',
+  red: 'text-neon-red',
+};
+
+interface Tooltip {
+  kind: 'dot' | 'label';
+  scenarioId: string;
+  stance?: Stance;
+  x: number;
+  y: number;
+  pinned: boolean;
+}
+
+export default function HorizonStrip({
+  scenarios,
+  events,
+  recentChanges,
+  currentYear,
+}: Props) {
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+  const [scrollEndReached, setScrollEndReached] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const axis = DEFAULT_AXIS_CONFIG;
+  const axisW = totalAxisWidth(axis);
+  const totalW = LABEL_COL_W + axisW;
+  const chartTop = HEADER_H;
+  const chartH = scenarios.length * ROW_H;
+  const totalH = chartTop + chartH + AXIS_H;
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  // Detect horizontal-scroll overflow for the "scroll →" affordance.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      setScrollEndReached(scrollLeft + clientWidth >= scrollWidth - 4);
+    };
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    return () => {
+      el.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+
+  // Dismiss pinned tooltip on Escape and on outside click.
+  useEffect(() => {
+    if (!tooltip?.pinned) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setTooltip(null);
+    };
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target?.closest('[data-horizon-interactive]')) {
+        setTooltip(null);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('click', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('click', onClick);
+    };
+  }, [tooltip?.pinned]);
+
+  // Pre-compute dot positions + collision offsets per scenario.
+  const dotLayout = useMemo(() => {
+    return scenarios.map((s) => {
+      const stances: Stance[] = ['optimistic', 'pragmatic', 'sceptical'];
+      const positions = stances.map((stance) => {
+        const entry = s[stance];
+        const band = entry.band ?? yearToBand(entry.year ?? null, currentYear);
+        const x = yearToX(entry.year ?? null, band, axis);
+        return { stance, x, band };
+      });
+      const offsets = dotCollisionOffsets(
+        positions.map((p) => ({ stance: p.stance, x: p.x })),
+      );
+      return { positions, offsets };
+    });
+  }, [scenarios, currentYear, axis]);
+
+  // Filter event markers to those within visible axis range.
+  const visibleEvents = useMemo(() => {
+    const minYear = axis.nearRange[0] - 1;
+    const maxYear = axis.farRange[1];
+    return events.filter((e) => e.year >= minYear && e.year <= maxYear);
+  }, [events, axis]);
+
+  return (
+    <div class="relative">
+      <div
+        ref={containerRef}
+        class="overflow-x-auto overflow-y-visible"
+        style="scrollbar-width: thin;"
+      >
+        <svg
+          viewBox={`0 0 ${totalW} ${totalH}`}
+          width={totalW}
+          height={totalH}
+          class="block"
+          role="img"
+          aria-labelledby="horizon-strip-title horizon-strip-desc"
+          preserveAspectRatio="xMidYMid meet"
+        >
+          <title id="horizon-strip-title">Five Horizons chart</title>
+          <desc id="horizon-strip-desc">
+            Arrival-year forecasts for five AI futures (AGI, Agentic Work, Robotics,
+            Software Automation, Education Disruption) across three worldviews
+            (optimistic, pragmatic, sceptical). Plotted on a non-uniform banded axis.
+          </desc>
+
+          {/* Zone dividers + labels */}
+          {(['near', 'mid', 'far', 'indefinite'] as Band[]).map((band) => {
+            const x = LABEL_COL_W + zoneStartX(band, axis);
+            const w = axis.widths[band];
+            return (
+              <g key={`zone-${band}`}>
+                {band !== 'near' && (
+                  <line
+                    x1={x - axis.zoneGap / 2}
+                    x2={x - axis.zoneGap / 2}
+                    y1={chartTop - 6}
+                    y2={chartTop + chartH + 6}
+                    stroke="var(--color-surface-light, #1e1e30)"
+                    stroke-width="1"
+                    stroke-dasharray="3 4"
+                  />
+                )}
+                <text
+                  x={x + w / 2}
+                  y={chartTop - 12}
+                  text-anchor="middle"
+                  class="font-mono fill-text-muted"
+                  style="font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase;"
+                >
+                  {band === 'indefinite' ? 'indefinite' : band}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Event markers (past milestones) — thin vertical lines behind rows */}
+          {visibleEvents.map((e) => {
+            const band = yearToBand(e.year, currentYear);
+            if (band === 'indefinite') return null;
+            const x = LABEL_COL_W + yearToX(e.year, band, axis);
+            return (
+              <g key={`event-${e.year}-${e.label}`} opacity="0.25">
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={chartTop}
+                  y2={chartTop + chartH}
+                  stroke="var(--color-text-muted, #6b7280)"
+                  stroke-width="1"
+                  stroke-dasharray="2 4"
+                />
+                <text
+                  x={x}
+                  y={chartTop + chartH + 18}
+                  text-anchor="middle"
+                  class="font-mono fill-text-muted"
+                  style="font-size: 9px;"
+                >
+                  {e.label}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Year ticks along the axis */}
+          {axisYearTicks(axis).map(({ year, band }) => {
+            const x = LABEL_COL_W + yearToX(year, band, axis);
+            return (
+              <g key={`tick-${year}`}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={chartTop + chartH}
+                  y2={chartTop + chartH + 4}
+                  stroke="var(--color-text-muted, #6b7280)"
+                  stroke-width="1"
+                />
+                <text
+                  x={x}
+                  y={chartTop + chartH + 34}
+                  text-anchor="middle"
+                  class="font-mono fill-text-muted"
+                  style="font-size: 10px;"
+                >
+                  {year}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Indefinite column header */}
+          <text
+            x={LABEL_COL_W + zoneStartX('indefinite', axis) + axis.widths.indefinite / 2}
+            y={chartTop + chartH + 34}
+            text-anchor="middle"
+            class="font-mono fill-text-muted"
+            style="font-size: 10px;"
+          >
+            ???
+          </text>
+
+          {/* Rows */}
+          {scenarios.map((s, rowIdx) => {
+            const rowY = chartTop + rowIdx * ROW_H;
+            const rowMidY = rowY + ROW_H / 2;
+            const { positions, offsets } = dotLayout[rowIdx];
+
+            // Envelope: rect from leftmost finite dot to rightmost finite dot.
+            const finite = positions.filter((p) => p.band !== 'indefinite');
+            const envelopeLeft = finite.length
+              ? Math.min(...finite.map((p) => p.x))
+              : null;
+            const envelopeRight = finite.length
+              ? Math.max(...finite.map((p) => p.x))
+              : null;
+
+            const changes = recentChanges[s.id] ?? [];
+
+            return (
+              <g key={`row-${s.id}`}>
+                {/* Faint row divider */}
+                {rowIdx > 0 && (
+                  <line
+                    x1={0}
+                    x2={totalW}
+                    y1={rowY}
+                    y2={rowY}
+                    stroke="var(--color-surface-light, #1e1e30)"
+                    stroke-width="1"
+                    opacity="0.3"
+                  />
+                )}
+
+                {/* Row label (massive mono) — interactive for definition overlay */}
+                <g
+                  data-horizon-interactive="true"
+                  style="cursor: pointer;"
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`${s.topic} — ${s.definition}`}
+                  onMouseEnter={(ev) =>
+                    setTooltip({
+                      kind: 'label',
+                      scenarioId: s.id,
+                      x: (ev.currentTarget as SVGElement).getBoundingClientRect().right,
+                      y: (ev.currentTarget as SVGElement).getBoundingClientRect().top,
+                      pinned: false,
+                    })
+                  }
+                  onMouseLeave={() => {
+                    if (!tooltip?.pinned) setTooltip(null);
+                  }}
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    setTooltip({
+                      kind: 'label',
+                      scenarioId: s.id,
+                      x: (ev.currentTarget as SVGElement).getBoundingClientRect().right,
+                      y: (ev.currentTarget as SVGElement).getBoundingClientRect().top,
+                      pinned: true,
+                    });
+                  }}
+                  onFocus={(ev) =>
+                    setTooltip({
+                      kind: 'label',
+                      scenarioId: s.id,
+                      x: (ev.currentTarget as SVGElement).getBoundingClientRect().right,
+                      y: (ev.currentTarget as SVGElement).getBoundingClientRect().top,
+                      pinned: false,
+                    })
+                  }
+                  onBlur={() => {
+                    if (!tooltip?.pinned) setTooltip(null);
+                  }}
+                >
+                  <text
+                    x={LABEL_COL_W - 16}
+                    y={rowMidY + 8}
+                    text-anchor="end"
+                    class={`font-mono font-bold ${ROW_ACCENT_CLASS[s.accent]}`}
+                    style="font-size: 26px; letter-spacing: 0.04em;"
+                  >
+                    {s.topic.toUpperCase()}
+                  </text>
+                  {s.contested && (
+                    <text
+                      x={LABEL_COL_W - 8}
+                      y={rowMidY - 14}
+                      text-anchor="end"
+                      class="fill-neon-amber"
+                      style="font-size: 14px;"
+                      aria-label="contested definition"
+                    >
+                      ⚠
+                    </text>
+                  )}
+                </g>
+
+                {/* Confidence envelope */}
+                {envelopeLeft != null && envelopeRight != null && envelopeRight > envelopeLeft && (
+                  <rect
+                    x={LABEL_COL_W + envelopeLeft}
+                    y={rowMidY - 18}
+                    width={envelopeRight - envelopeLeft}
+                    height={36}
+                    fill={`var(--color-neon-${s.accent}, #5ab8d4)`}
+                    opacity={ENVELOPE_OPACITY}
+                    rx={18}
+                  />
+                )}
+
+                {/* Ghost dots + drift arrows (from recent shifts) */}
+                {changes.map((c, ci) => {
+                  if (c.from == null || c.to == null) return null;
+                  const fromBand = yearToBand(c.from, currentYear);
+                  const toBand = yearToBand(c.to, currentYear);
+                  if (fromBand === 'indefinite' || toBand === 'indefinite') return null;
+                  const xFrom = LABEL_COL_W + yearToX(c.from, fromBand, axis);
+                  const xTo = LABEL_COL_W + yearToX(c.to, toBand, axis);
+                  const offsetY = offsets[c.stance] ?? 0;
+                  return (
+                    <g key={`ghost-${s.id}-${c.stance}-${ci}`} opacity="0.5">
+                      <circle
+                        cx={xFrom}
+                        cy={rowMidY + offsetY}
+                        r={DOT_GHOST_R}
+                        fill="none"
+                        stroke={STANCE_COLORS[c.stance]}
+                        stroke-width="1.5"
+                        stroke-dasharray="2 2"
+                      />
+                      <line
+                        x1={xFrom + DOT_GHOST_R}
+                        y1={rowMidY + offsetY}
+                        x2={xTo - DOT_R - 2}
+                        y2={rowMidY + offsetY}
+                        stroke={STANCE_COLORS[c.stance]}
+                        stroke-width="1.5"
+                        marker-end={`url(#arrow-${c.stance})`}
+                      />
+                    </g>
+                  );
+                })}
+
+                {/* Dots */}
+                {positions.map((p) => {
+                  const cx = LABEL_COL_W + p.x;
+                  const cy = rowMidY + (offsets[p.stance] ?? 0);
+                  const entry = s[p.stance];
+                  const isIndefinite = p.band === 'indefinite';
+                  return (
+                    <g
+                      key={`dot-${s.id}-${p.stance}`}
+                      data-horizon-interactive="true"
+                      tabIndex={0}
+                      role="button"
+                      style={`cursor: pointer; animation: horizon-dot-in 600ms ease-out ${rowIdx * 80}ms both;`}
+                      aria-label={`${s.topic} ${p.stance}: ${entry.timeframe}`}
+                      onMouseEnter={(ev) => {
+                        if (tooltip?.pinned) return;
+                        const r = (ev.currentTarget as SVGElement).getBoundingClientRect();
+                        setTooltip({
+                          kind: 'dot',
+                          scenarioId: s.id,
+                          stance: p.stance,
+                          x: r.left + r.width / 2,
+                          y: r.top,
+                          pinned: false,
+                        });
+                      }}
+                      onMouseLeave={() => {
+                        if (!tooltip?.pinned) setTooltip(null);
+                      }}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        const r = (ev.currentTarget as SVGElement).getBoundingClientRect();
+                        setTooltip({
+                          kind: 'dot',
+                          scenarioId: s.id,
+                          stance: p.stance,
+                          x: r.left + r.width / 2,
+                          y: r.top,
+                          pinned: true,
+                        });
+                      }}
+                      onFocus={(ev) => {
+                        const r = (ev.currentTarget as SVGElement).getBoundingClientRect();
+                        setTooltip({
+                          kind: 'dot',
+                          scenarioId: s.id,
+                          stance: p.stance,
+                          x: r.left + r.width / 2,
+                          y: r.top,
+                          pinned: false,
+                        });
+                      }}
+                      onBlur={() => {
+                        if (!tooltip?.pinned) setTooltip(null);
+                      }}
+                      onKeyDown={(ev) => {
+                        if (ev.key === 'Enter' || ev.key === ' ') {
+                          ev.preventDefault();
+                          window.location.href = `/horizon#${s.id}`;
+                        }
+                      }}
+                    >
+                      {isIndefinite ? (
+                        <rect
+                          x={cx - DOT_R}
+                          y={cy - DOT_R}
+                          width={DOT_R * 2}
+                          height={DOT_R * 2}
+                          fill="none"
+                          stroke={STANCE_COLORS[p.stance]}
+                          stroke-width="2"
+                          rx="2"
+                        />
+                      ) : (
+                        <circle
+                          cx={cx}
+                          cy={cy}
+                          r={DOT_R}
+                          fill={STANCE_COLORS[p.stance]}
+                          stroke="var(--color-void, #0c0c14)"
+                          stroke-width="2"
+                        />
+                      )}
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })}
+
+          {/* Arrow marker defs for drift lines */}
+          <defs>
+            {(['optimistic', 'pragmatic', 'sceptical'] as Stance[]).map((st) => (
+              <marker
+                key={`arrow-${st}`}
+                id={`arrow-${st}`}
+                markerWidth="6"
+                markerHeight="6"
+                refX="5"
+                refY="3"
+                orient="auto"
+              >
+                <path d="M0,0 L0,6 L6,3 Z" fill={STANCE_COLORS[st]} />
+              </marker>
+            ))}
+          </defs>
+
+          {/* Global styles (animation keyframes) */}
+          <style>{`
+            @keyframes horizon-dot-in {
+              0% { opacity: 0; transform: translateX(-40px); }
+              100% { opacity: 1; transform: translateX(0); }
+            }
+          `}</style>
+        </svg>
+      </div>
+
+      {/* Scroll affordance */}
+      {hydrated && !scrollEndReached && (
+        <div
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-[var(--color-void,#0c0c14)] to-transparent flex items-center justify-end pr-2 font-mono text-xs text-text-muted"
+        >
+          scroll →
+        </div>
+      )}
+
+      {/* Tooltip */}
+      {hydrated && tooltip && (
+        <TooltipView tooltip={tooltip} scenarios={scenarios} recentChanges={recentChanges} />
+      )}
+
+      {/* Stance legend */}
+      <div class="mt-4 flex items-center gap-6 font-mono text-xs text-text-muted flex-wrap">
+        {(['optimistic', 'pragmatic', 'sceptical'] as Stance[]).map((st) => (
+          <span class="inline-flex items-center gap-2" key={st}>
+            <span
+              class="inline-block h-3 w-3 rounded-full"
+              style={`background:${STANCE_COLORS[st]};`}
+            />
+            {STANCE_LABEL[st]}
+          </span>
+        ))}
+        <span class="inline-flex items-center gap-2">
+          <span class="inline-block h-3 w-3 rounded-full border border-text-muted/60 border-dashed" />
+          ghost dot + drift arrow = change in last 30 days
+        </span>
+        <span class="inline-flex items-center gap-2">
+          <span class="inline-block h-3 w-3 border border-text-muted/60" style="border-radius:2px;" />
+          indefinite (no year)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TooltipView({
+  tooltip,
+  scenarios,
+  recentChanges,
+}: {
+  tooltip: Tooltip;
+  scenarios: ScenarioForStrip[];
+  recentChanges: Record<string, ShiftChange[]>;
+}) {
+  const scenario = scenarios.find((s) => s.id === tooltip.scenarioId);
+  if (!scenario) return null;
+
+  const stance = tooltip.stance;
+  const entry = stance ? scenario[stance] : null;
+  const changes = recentChanges[scenario.id] ?? [];
+  const driftForStance = stance ? changes.find((c) => c.stance === stance) : null;
+
+  const style = `left:${Math.max(12, tooltip.x - 180)}px; top:${Math.max(12, tooltip.y - 12)}px; transform: translateY(-100%);`;
+
+  return (
+    <div
+      class="fixed z-50 max-w-sm glass-card rounded-lg p-4 shadow-xl border border-surface-light pointer-events-auto"
+      style={style}
+      role="dialog"
+      aria-modal={tooltip.pinned ? 'true' : undefined}
+    >
+      <div class="font-mono text-xs uppercase tracking-widest text-text-muted mb-1">
+        {scenario.topic}
+        {scenario.contested && (
+          <span class="ml-2 text-neon-amber">⚠ contested</span>
+        )}
+      </div>
+
+      {tooltip.kind === 'label' && (
+        <>
+          <p class="text-sm text-text-bright leading-snug mb-2">
+            {scenario.definition}
+          </p>
+          {scenario.contested && scenario.debate_ref && (
+            <a
+              href={`/horizon#${scenario.debate_ref}`}
+              class="font-mono text-xs text-neon-amber hover:underline"
+            >
+              See debate →
+            </a>
+          )}
+        </>
+      )}
+
+      {tooltip.kind === 'dot' && entry && stance && (
+        <>
+          <div class="flex items-baseline gap-2 mb-2">
+            <span
+              class="font-mono text-xs uppercase"
+              style={`color:${STANCE_COLORS[stance]};`}
+            >
+              {STANCE_LABEL[stance]}
+            </span>
+            <span class="font-mono text-xs text-text-bright">
+              {entry.timeframe}
+            </span>
+          </div>
+          <p class="text-xs text-text-muted mb-2 leading-snug">
+            {entry.implication}
+          </p>
+          {driftForStance && driftForStance.from != null && driftForStance.to != null && (
+            <p class="font-mono text-[11px] text-neon-amber leading-snug mb-2">
+              drift: {driftForStance.from} → {driftForStance.to}
+              {driftForStance.delta_months != null && (
+                <> ({formatDelta(driftForStance.delta_months)})</>
+              )}
+            </p>
+          )}
+          <a
+            href={`/horizon#${scenario.id}`}
+            class="font-mono text-xs text-neon-cyan hover:underline"
+          >
+            Read the full scenario →
+          </a>
+        </>
+      )}
+
+      {tooltip.pinned && (
+        <button
+          type="button"
+          class="absolute top-2 right-2 text-text-muted hover:text-text-bright font-mono text-xs"
+          aria-label="close tooltip"
+          onClick={(e) => {
+            e.stopPropagation();
+            // Handled by parent via outside-click; nothing to do here, but
+            // the button provides a keyboard-reachable dismissal target.
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+          }}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}
+
+function formatDelta(months: number): string {
+  const abs = Math.abs(months);
+  const sign = months > 0 ? 'later' : 'earlier';
+  if (abs < 12) return `${abs} mo ${sign}`;
+  const years = Math.round(abs / 12);
+  return `${years} yr ${sign}`;
+}
+
+function axisYearTicks(axis: typeof DEFAULT_AXIS_CONFIG) {
+  const ticks: { year: number; band: Band }[] = [];
+  for (let y = axis.nearRange[0]; y <= axis.nearRange[1]; y++) ticks.push({ year: y, band: 'near' });
+  for (let y = axis.midRange[0]; y <= axis.midRange[1]; y += 2) ticks.push({ year: y, band: 'mid' });
+  // Far zone gets just the endpoints
+  ticks.push({ year: axis.farRange[0], band: 'far' });
+  ticks.push({ year: Math.floor((axis.farRange[0] + axis.farRange[1]) / 2), band: 'far' });
+  ticks.push({ year: axis.farRange[1], band: 'far' });
+  return ticks;
+}

--- a/src/components/HorizonStrip.tsx
+++ b/src/components/HorizonStrip.tsx
@@ -241,13 +241,14 @@ export default function HorizonStrip({
             );
           })}
 
-          {/* Event markers (past milestones) — thin vertical lines behind rows */}
+          {/* Event markers (past milestones) — thin vertical lines behind rows,
+              labels rotated -30deg so adjacent events don't collide horizontally. */}
           {visibleEvents.map((e) => {
             const band = yearToBand(e.year, currentYear);
             if (band === 'indefinite') return null;
             const x = LABEL_COL_W + yearToX(e.year, band, axis);
             return (
-              <g key={`event-${e.year}-${e.label}`} opacity="0.25">
+              <g key={`event-${e.year}-${e.label}`} opacity="0.35">
                 <line
                   x1={x}
                   x2={x}
@@ -259,8 +260,9 @@ export default function HorizonStrip({
                 />
                 <text
                   x={x}
-                  y={chartTop + chartH + 18}
-                  text-anchor="middle"
+                  y={chartTop + chartH + 46}
+                  text-anchor="end"
+                  transform={`rotate(-30 ${x} ${chartTop + chartH + 46})`}
                   class="font-mono fill-text-muted"
                   style="font-size: 9px;"
                 >

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -229,14 +229,26 @@ const horizonDebates = defineCollection({
     .strict(),
 });
 
+// Banded axis for the /horizon/five Five Horizons strip (2026-04-22).
+// year is required unless band === 'indefinite' (see superRefine below).
+// yearToBand auto-derivation lives in src/lib/horizon-axis.ts — the schema
+// accepts whatever value is written, so manual overrides are honoured.
+const horizonBand = z.enum(['near', 'mid', 'far', 'indefinite']);
+
 const horizonScenarioBranch = z
   .object({
     timeframe: z.string().min(1),
+    year: z.number().int().min(2026).max(2060).optional(),
+    band: horizonBand.optional(),
     assumptions: z.string().min(1),
     blockers: z.string().min(1),
     implication: z.string().min(1),
   })
-  .strict();
+  .strict()
+  .refine(
+    (v) => v.band === 'indefinite' || typeof v.year === 'number',
+    { message: 'stance must have year (unless band="indefinite")' },
+  );
 
 const horizonScenarios = defineCollection({
   loader: file('src/data/horizon/scenarios.json'),
@@ -247,6 +259,11 @@ const horizonScenarios = defineCollection({
       // Outside #7: scenarios need theme + related binding.
       themes: horizonThemeArray,
       related: z.array(z.string()).optional(),
+      // Five Horizons additions (2026-04-22): crisp definition rendered at top
+      // of Compare View cards AND in the /horizon/five chart tooltip.
+      definition: z.string().min(1).max(200),
+      contested: z.boolean().optional(),
+      debate_ref: z.string().regex(DEBATE_ID).optional(),
       optimistic: horizonScenarioBranch,
       pragmatic: horizonScenarioBranch,
       sceptical: horizonScenarioBranch,

--- a/src/data/horizon/debates.json
+++ b/src/data/horizon/debates.json
@@ -120,5 +120,29 @@
         "next-computer-use-agents-find-narrow-fit"
       ]
     }
+  },
+  {
+    "id": "debate-what-counts-as-agi",
+    "question": "What actually counts as AGI — economic substitution, cognitive breadth, or something else entirely?",
+    "themes": [
+      "models",
+      "society"
+    ],
+    "for": {
+      "argument": "The useful definition is economic: a system is AGI when it can reliably perform most paid knowledge work at human level or better, across domains, without task-specific retraining. This framing is measurable, matters commercially and treats “general” as a threshold of breadth rather than a philosophical claim about understanding. Reasoning models plus tool use already point at this definition, even if the threshold is years away.",
+      "supporting": [
+        "past-2024-o1-reasoning-shift",
+        "past-2025-deepseek-r1",
+        "past-2023-gpt-4-release"
+      ]
+    },
+    "against": {
+      "argument": "The economic definition smuggles in a philosophical claim and hides the hard part. Genuine general intelligence arguably requires durable goals, embodied experience, robust world-modelling and cross-domain transfer that current systems do not have even when they score well on benchmarks. A system that passes every exam and still cannot run a small business on its own is not general; it is a very capable text engine. The label matters because it shapes policy, investment and safety expectations.",
+      "supporting": [
+        "past-2016-alphago-lee-sedol",
+        "past-2023-ai-safety-public-view",
+        "past-2024-gemini-2-agentic-era"
+      ]
+    }
   }
 ]

--- a/src/data/horizon/scenarios.json
+++ b/src/data/horizon/scenarios.json
@@ -6,20 +6,29 @@
       "models",
       "society"
     ],
+    "definition": "Systems matching or exceeding human performance across most cognitive tasks, including ones outside their training distribution, without task-specific retraining.",
+    "contested": true,
+    "debate_ref": "debate-what-counts-as-agi",
     "optimistic": {
       "timeframe": "by end of 2028",
+      "year": 2028,
+      "band": "near",
       "assumptions": "Reasoning, memory, tool use and self-improvement keep compounding until frontier systems can transfer robustly across most cognitive domains at roughly human level.",
       "blockers": "The last 20% of reliability, autonomy and world-model grounding proves far harder than scaling advocates expect.",
       "implication": "Build for an agent-native world now: outcome-based products, tiny oversight teams, and businesses that assume intelligence becomes abundant before trust does."
     },
     "pragmatic": {
       "timeframe": "2032-2035",
+      "year": 2033,
+      "band": "mid",
       "assumptions": "Systems become extraordinary co-workers first, and only later cross the threshold into genuinely general autonomous competence across domains.",
       "blockers": "Deployment friction, safety constraints and evaluation gaps keep real-world capability behind benchmark capability for years.",
       "implication": "Design around hybrid intelligence: let machines dominate bounded cognition while humans keep accountability, cross-functional judgement and final authority."
     },
     "sceptical": {
       "timeframe": "not before the 2040s",
+      "year": 2045,
+      "band": "far",
       "assumptions": "Human-level general intelligence depends on embodiment, durable goals, social learning and world models that current architectures do not naturally supply.",
       "blockers": "Digital-only systems start generalising across messy real-world domains with minimal scaffolding and without brittle failure modes.",
       "implication": "Optimise for augmentation, governance and competitive advantage from AI tools, not for AGI-timing theatre."
@@ -33,20 +42,27 @@
       "enterprise",
       "work"
     ],
+    "definition": "AI systems that autonomously execute multi-step knowledge work across tools, queues and approval boundaries, owning outcomes end-to-end rather than assisting a human operator.",
     "optimistic": {
       "timeframe": "by end of 2027",
+      "year": 2027,
+      "band": "near",
       "assumptions": "Tool use, memory, permissions, evaluation and error recovery improve fast enough that agents can own large volumes of queue-based knowledge work without human approval loops.",
       "blockers": "Identity, auditability, exception handling and liability stay unresolved long enough to stop organisations trusting unattended execution.",
       "implication": "Build narrow, high-volume domain agents now and wrap them in approval tiers, rollback paths and outcome-level monitoring."
     },
     "pragmatic": {
       "timeframe": "2029-2031",
+      "year": 2030,
+      "band": "near",
       "assumptions": "Agents become dependable in structured workflows first, while open-ended office work remains mostly supervised because tacit context is still hard to encode.",
       "blockers": "Enterprise data stays fragmented and process owners fail to redesign workflows around machine delegation.",
       "implication": "Sell partial autonomy, not full replacement: hand-offs, triage, drafting, reconciliation and escalation will land before lights-out execution."
     },
     "sceptical": {
       "timeframe": "mid-2030s or later",
+      "year": 2036,
+      "band": "far",
       "assumptions": "Most knowledge work hides politics, ambiguity, negotiation and accountability that cannot be cleanly reduced to tools plus prompts.",
       "blockers": "Agents prove they can recover from ambiguity, manage cross-system state and own consequences in messy live environments.",
       "implication": "Treat agents as force multipliers for people and focus on better interfaces, memory and review rather than labour-substitution bets."
@@ -60,20 +76,27 @@
       "infrastructure",
       "work"
     ],
+    "definition": "General-purpose physical robots (humanoid or otherwise) that are commercially routine, not demo-quality, with fleet-deployable reliability and workable unit economics.",
     "optimistic": {
       "timeframe": "by 2030",
+      "year": 2030,
+      "band": "near",
       "assumptions": "Vision-language-action models, dexterity, battery performance and manufacturing scale improve together quickly enough to make general-purpose robots commercially routine and cheap.",
       "blockers": "Reliability in cluttered environments, safety certification and service economics fail to move from demo quality to fleet quality.",
       "implication": "Start designing robot-ready workflows, facilities and software now, because the integration layer will matter as much as the hardware."
     },
     "pragmatic": {
       "timeframe": "2033-2036",
+      "year": 2035,
+      "band": "mid",
       "assumptions": "General-purpose robotics lands first in warehouses, factories, logistics and other structured commercial environments before the home catches up.",
       "blockers": "Unit economics stay weak because teleoperation, maintenance and failure recovery remain too expensive.",
       "implication": "Build for structured environments and mixed fleets, where robot coordination, observability and process redesign create the first durable value."
     },
     "sceptical": {
       "timeframe": "not before the late 2030s",
+      "year": 2038,
+      "band": "far",
       "assumptions": "True general-purpose robotics is a full-stack systems problem, and manipulation, safety and upkeep are much harder than the current curve implies.",
       "blockers": "On-device robot models plus mass manufacturing crack reliability and cost at the same time.",
       "implication": "Treat humanoids as long-duration options and keep investing in fixed automation, sensors and workflow software that pays off sooner."
@@ -87,20 +110,27 @@
       "enterprise",
       "work"
     ],
+    "definition": "Coding agents reliably owning the loop from ticket to monitored production deploy across large codebases, leaving humans mostly specifying, reviewing and steering.",
     "optimistic": {
       "timeframe": "by end of 2028",
+      "year": 2028,
+      "band": "near",
       "assumptions": "Long-horizon coding agents become strong enough at planning, editing, testing, migration and repository memory that humans mostly specify, review and steer.",
       "blockers": "Security, reproducibility, architecture drift and repo-specific context keep agents from owning production changes at scale.",
       "implication": "Rebuild engineering around evaluation, review policy and product judgement, because typing and boilerplate stop being the scarce skill."
     },
     "pragmatic": {
       "timeframe": "2030-2032",
+      "year": 2031,
+      "band": "mid",
       "assumptions": "AI takes over most routine implementation and maintenance, but humans still dominate architecture, incident response, stakeholder translation and high-risk decisions.",
       "blockers": "Firms fail to trust generated changes in production and never build the testing and governance needed for deeper automation.",
       "implication": "Prepare for smaller engineering teams with stronger QA, clearer specs and codebases designed to be legible to agents."
     },
     "sceptical": {
       "timeframe": "not before the mid-2030s",
+      "year": 2036,
+      "band": "far",
       "assumptions": "Production software is mainly about ambiguous requirements, coordination, risk and long-tail maintenance rather than writing lines of code.",
       "blockers": "Agents start reliably running the full loop from ticket to monitored deploy across large, messy codebases.",
       "implication": "Invest in developer leverage and system clarity, not in simple headcount-reduction stories."
@@ -114,20 +144,26 @@
       "work",
       "society"
     ],
+    "definition": "AI tutoring and assessment displacing institutional course and credential delivery as the primary structure through which people learn and signal mastery.",
     "optimistic": {
       "timeframe": "by 2030",
+      "year": 2030,
+      "band": "near",
       "assumptions": "AI tutoring becomes dramatically better and cheaper than conventional content delivery, and assessment adapts fast enough to preserve trust in learning outcomes.",
       "blockers": "Credentialing inertia, safeguarding, procurement cycles and political resistance keep institutions tied to legacy delivery models.",
       "implication": "Build assessment, coaching, learning-record and teacher-orchestration products rather than more static content libraries."
     },
     "pragmatic": {
       "timeframe": "2032-2035",
+      "year": 2034,
+      "band": "mid",
       "assumptions": "AI transforms tutoring, practice and feedback quickly, but schools, universities and employers retain the institutional shell of courses, cohorts and credentials.",
       "blockers": "Demonstrated learning gains become so overwhelming that institutions are forced to redesign faster than expected.",
       "implication": "Plug into existing institutions instead of trying to replace them; the winning tools will fit classrooms, campuses and compliance."
     },
     "sceptical": {
       "timeframe": "not this generation",
+      "band": "indefinite",
       "assumptions": "Education is not primarily content delivery; it is socialisation, signalling, childcare, norm formation and supervised practice, so AI enhances learning without replacing structured learning.",
       "blockers": "Employers stop trusting conventional credentials and start trusting AI-mediated mastery records instead.",
       "implication": "Focus on teacher augmentation, administrative relief and better evidence of skill, not on betting against the institution itself."

--- a/src/lib/horizon-axis.ts
+++ b/src/lib/horizon-axis.ts
@@ -1,0 +1,127 @@
+// Banded axis helpers for the Five Horizons strip (/horizon/five).
+//
+// The chart renders on a non-uniform axis: NEAR (2026-2030) gets full
+// per-year precision, MID (2031-2035) reads in 2-year buckets, FAR
+// (2036-2045) is a rough zone, INDEFINITE is a pinned right column.
+// Fixed pixel width per zone, not proportional to year span. Reader-model
+// decision: near-term decisions deserve the screen real estate.
+//
+// Kept in sync with scripts/validate-horizon-refs.mjs (duplicated there
+// because that file is .mjs and cannot import TypeScript).
+
+export type Band = 'near' | 'mid' | 'far' | 'indefinite';
+export type Stance = 'optimistic' | 'pragmatic' | 'sceptical';
+
+export const BAND_NEAR_MAX_DELTA = 4;
+export const BAND_MID_MAX_DELTA = 9;
+export const BAND_FAR_MAX_DELTA = 19;
+
+export function yearToBand(
+  year: number | null | undefined,
+  currentYear: number,
+): Band {
+  if (year == null) return 'indefinite';
+  const delta = year - currentYear;
+  if (delta <= BAND_NEAR_MAX_DELTA) return 'near';
+  if (delta <= BAND_MID_MAX_DELTA) return 'mid';
+  if (delta <= BAND_FAR_MAX_DELTA) return 'far';
+  return 'indefinite';
+}
+
+export interface BandedAxisConfig {
+  widths: Record<Band, number>;
+  nearRange: [number, number];
+  midRange: [number, number];
+  farRange: [number, number];
+  zoneGap: number;
+}
+
+export const DEFAULT_AXIS_CONFIG: BandedAxisConfig = {
+  widths: { near: 420, mid: 260, far: 300, indefinite: 140 },
+  nearRange: [2026, 2030],
+  midRange: [2031, 2035],
+  farRange: [2036, 2045],
+  zoneGap: 12,
+};
+
+export function zoneStartX(band: Band, config: BandedAxisConfig): number {
+  const { widths, zoneGap } = config;
+  if (band === 'near') return 0;
+  if (band === 'mid') return widths.near + zoneGap;
+  if (band === 'far') return widths.near + zoneGap + widths.mid + zoneGap;
+  return widths.near + zoneGap + widths.mid + zoneGap + widths.far + zoneGap;
+}
+
+export function totalAxisWidth(config: BandedAxisConfig): number {
+  const { widths, zoneGap } = config;
+  return widths.near + widths.mid + widths.far + widths.indefinite + zoneGap * 3;
+}
+
+export function yearToX(
+  year: number | null | undefined,
+  band: Band,
+  config: BandedAxisConfig,
+): number {
+  const zs = zoneStartX(band, config);
+  if (band === 'indefinite' || year == null) {
+    return zs + config.widths.indefinite / 2;
+  }
+  const range = band === 'near' ? config.nearRange : band === 'mid' ? config.midRange : config.farRange;
+  const width = band === 'near' ? config.widths.near : band === 'mid' ? config.widths.mid : config.widths.far;
+  const [s, e] = range;
+  const frac = clamp((year - s) / (e - s), 0, 1);
+  return zs + frac * width;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// When two or three dots in a row crowd the same x, fan them vertically so
+// nothing occludes. Returns a per-stance vertical offset in px (positive =
+// below row centreline).
+export interface DotPosition {
+  stance: Stance;
+  x: number;
+}
+
+const COLLISION_THRESHOLD_PX = 14;
+const COLLISION_OFFSET_PX = 7;
+
+export function dotCollisionOffsets(
+  dots: DotPosition[],
+): Record<Stance, number> {
+  const sorted = [...dots].sort((a, b) => a.x - b.x);
+  const groups: DotPosition[][] = [];
+  let current: DotPosition[] = [];
+  for (const d of sorted) {
+    if (current.length === 0) {
+      current.push(d);
+    } else if (d.x - current[current.length - 1].x <= COLLISION_THRESHOLD_PX) {
+      current.push(d);
+    } else {
+      groups.push(current);
+      current = [d];
+    }
+  }
+  if (current.length) groups.push(current);
+
+  const offsets: Record<Stance, number> = {
+    optimistic: 0,
+    pragmatic: 0,
+    sceptical: 0,
+  };
+  for (const group of groups) {
+    if (group.length === 1) {
+      offsets[group[0].stance] = 0;
+    } else if (group.length === 2) {
+      offsets[group[0].stance] = -COLLISION_OFFSET_PX;
+      offsets[group[1].stance] = COLLISION_OFFSET_PX;
+    } else {
+      offsets[group[0].stance] = -COLLISION_OFFSET_PX * 2;
+      offsets[group[1].stance] = 0;
+      offsets[group[2].stance] = COLLISION_OFFSET_PX * 2;
+    }
+  }
+  return offsets;
+}

--- a/src/pages/horizon.astro
+++ b/src/pages/horizon.astro
@@ -247,6 +247,21 @@ function stanceAccent(stance: 'optimistic' | 'pragmatic' | 'sceptical'): 'green'
     <p class="font-mono text-xs text-text-muted/60 text-center">
       {sortedPast.length} past turning points · {sortedNow.length} now signals · {nextEntries.length} next forecasts
     </p>
+
+    <!-- Five Horizons entry point: hero-area button to the standalone map. -->
+    <div class="mt-8 text-center">
+      <a
+        href="/horizon/five"
+        class="inline-flex items-center gap-3 px-5 py-3 bg-surface border border-neon-green/30 rounded-lg hover:border-neon-green/70 hover:bg-surface-light/40 transition-all group"
+      >
+        <span class="font-mono text-xs uppercase tracking-widest text-neon-green glow-green">
+          Five Horizons
+        </span>
+        <span class="font-mono text-xs text-text-muted group-hover:text-text-bright transition-colors">
+          where consensus sits — single chart, five paths →
+        </span>
+      </a>
+    </div>
   </section>
 
   <div class="glow-divider mb-12 max-w-5xl mx-auto" style="--divider-color: rgba(90, 184, 212, 0.15)"></div>
@@ -478,14 +493,18 @@ function stanceAccent(stance: 'optimistic' | 'pragmatic' | 'sceptical'): 'green'
       <div class="space-y-10">
         {scenarioEntries.map((entry) => (
           <article
+            id={entry.id}
             data-horizon-card
             data-horizon-lane="scenarios"
             data-themes={entry.data.themes.join(',')}
-            class="bg-surface border border-surface-light rounded-xl p-6"
+            class="bg-surface border border-surface-light rounded-xl p-6 scroll-mt-24"
           >
-            <div class="flex flex-wrap items-baseline justify-between gap-3 mb-5">
+            <div class="flex flex-wrap items-baseline justify-between gap-3 mb-3">
               <h3 class="font-mono text-xl font-bold text-text-bright glow-amber">
                 {entry.data.topic}
+                {entry.data.contested && (
+                  <span class="ml-2 text-neon-amber text-base" aria-label="contested definition">⚠</span>
+                )}
               </h3>
               <div class="flex flex-wrap gap-1.5">
                 {entry.data.themes.map((t) => (
@@ -493,6 +512,21 @@ function stanceAccent(stance: 'optimistic' | 'pragmatic' | 'sceptical'): 'green'
                 ))}
               </div>
             </div>
+
+            <p class="text-sm text-text-muted leading-relaxed mb-5 italic">
+              {entry.data.definition}
+              {entry.data.contested && entry.data.debate_ref && (
+                <>
+                  {' '}
+                  <a
+                    href={`#${entry.data.debate_ref}`}
+                    class="not-italic font-mono text-xs text-neon-amber hover:underline"
+                  >
+                    See debate →
+                  </a>
+                </>
+              )}
+            </p>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
               {(['optimistic', 'pragmatic', 'sceptical'] as const).map((stance) => {
@@ -567,10 +601,11 @@ function stanceAccent(stance: 'optimistic' | 'pragmatic' | 'sceptical'): 'green'
       <div class="space-y-8">
         {debateEntries.map((entry) => (
           <article
+            id={entry.id}
             data-horizon-card
             data-horizon-lane="debates"
             data-themes={entry.data.themes.join(',')}
-            class="bg-surface border border-surface-light rounded-xl p-6"
+            class="bg-surface border border-surface-light rounded-xl p-6 scroll-mt-24"
           >
             <div class="flex flex-wrap items-baseline justify-between gap-3 mb-5">
               <h3 class="font-mono text-lg md:text-xl font-bold text-text-bright glow-amber leading-snug">

--- a/src/pages/horizon/five.astro
+++ b/src/pages/horizon/five.astro
@@ -48,14 +48,36 @@ const scenarios: ScenarioForStrip[] = ORDER.map((id) => {
   };
 });
 
-// Event markers: post-2025 past-lane milestones (pre-2025 falls off the axis).
+// Event markers: up to 3 post-2025 Past-lane milestones, inflection-type
+// preferred (keeps the chart's time-anchor depth without visual clutter).
+// Labels in Past tend to be multi-clause; we take the first 2 words so rotated
+// text stays legible.
+const PREFERRED_SIGNAL: Set<string> = new Set(['inflection']);
+const MAX_EVENTS = 3;
+
+function shortEventLabel(title: string): string {
+  const head = title.split(/[—:(]/)[0].trim();
+  const words = head.split(/\s+/).slice(0, 2).join(' ');
+  return words.slice(0, 14);
+}
+
 const events: EventMarker[] = pastEntries
   .filter((e) => e.data.date >= '2025-01-01')
   .map((e) => ({
     year: Number(e.data.date.slice(0, 4)),
-    // Short label: strip trailing detail, keep key concept.
-    label: e.data.title.split(/[—:(]/)[0].trim().slice(0, 22),
+    label: shortEventLabel(e.data.title),
+    signal_type: e.data.signal_type,
+    date: e.data.date,
   }))
+  // Sort most-recent first so cap drops older events; prefer inflections.
+  .sort((a, b) => {
+    const aPref = PREFERRED_SIGNAL.has(a.signal_type) ? 0 : 1;
+    const bPref = PREFERRED_SIGNAL.has(b.signal_type) ? 0 : 1;
+    if (aPref !== bPref) return aPref - bPref;
+    return b.date.localeCompare(a.date);
+  })
+  .slice(0, MAX_EVENTS)
+  .map(({ year, label }) => ({ year, label }))
   .sort((a, b) => a.year - b.year);
 
 // Shift log (the same source that powers /horizon's shift log). Filter to

--- a/src/pages/horizon/five.astro
+++ b/src/pages/horizon/five.astro
@@ -1,0 +1,226 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+import HorizonStrip from '../../components/HorizonStrip.tsx';
+import type {
+  ScenarioForStrip,
+  EventMarker,
+  ShiftChange,
+} from '../../components/HorizonStrip.tsx';
+import shiftsData from '../../data/horizon/shifts.json';
+
+// Load horizon data.
+const scenarioEntries = await getCollection('horizonScenarios');
+const pastEntries = await getCollection('horizonPast');
+
+// Row-accent mapping (one neon colour per horizon, stable across the page).
+const TOPIC_ACCENT: Record<string, ScenarioForStrip['accent']> = {
+  'scenario-agi': 'amber',
+  'scenario-agentic-work': 'cyan',
+  'scenario-robotics': 'purple',
+  'scenario-software-automation': 'green',
+  'scenario-education-disruption': 'red',
+};
+
+// Canonical order (top to bottom on the chart).
+const ORDER = [
+  'scenario-agi',
+  'scenario-agentic-work',
+  'scenario-robotics',
+  'scenario-software-automation',
+  'scenario-education-disruption',
+];
+
+const scenarios: ScenarioForStrip[] = ORDER.map((id) => {
+  const entry = scenarioEntries.find((e) => e.id === id);
+  if (!entry) throw new Error(`Missing scenario ${id}`);
+  return {
+    id: entry.id,
+    topic: entry.data.topic,
+    themes: entry.data.themes,
+    definition: entry.data.definition,
+    contested: entry.data.contested,
+    debate_ref: entry.data.debate_ref,
+    accent: TOPIC_ACCENT[entry.id] ?? 'cyan',
+    optimistic: entry.data.optimistic,
+    pragmatic: entry.data.pragmatic,
+    sceptical: entry.data.sceptical,
+  };
+});
+
+// Event markers: post-2025 past-lane milestones (pre-2025 falls off the axis).
+const events: EventMarker[] = pastEntries
+  .filter((e) => e.data.date >= '2025-01-01')
+  .map((e) => ({
+    year: Number(e.data.date.slice(0, 4)),
+    // Short label: strip trailing detail, keep key concept.
+    label: e.data.title.split(/[—:(]/)[0].trim().slice(0, 22),
+  }))
+  .sort((a, b) => a.year - b.year);
+
+// Shift log (the same source that powers /horizon's shift log). Filter to
+// scenarios-lane entries with a `changes` array inside the last 30 days.
+type Shift = {
+  date: string;
+  lane: string;
+  verb: string;
+  subject: string;
+  sha: string;
+  changes?: ShiftChange[];
+};
+const allShifts = shiftsData as Shift[];
+const CUTOFF_DAYS = 30;
+const cutoff = new Date();
+cutoff.setUTCDate(cutoff.getUTCDate() - CUTOFF_DAYS);
+const cutoffISO = cutoff.toISOString().slice(0, 10);
+
+const recentScenarioShifts = allShifts
+  .filter(
+    (s) =>
+      s.lane === 'scenarios' &&
+      s.date >= cutoffISO &&
+      Array.isArray(s.changes) &&
+      s.changes.length > 0,
+  )
+  .sort((a, b) => b.date.localeCompare(a.date));
+
+// recentChanges keyed by scenario id — passed to HorizonStrip for ghost dots.
+const recentChanges: Record<string, ShiftChange[]> = {};
+for (const s of recentScenarioShifts) {
+  for (const c of s.changes!) {
+    if (!recentChanges[c.horizon]) recentChanges[c.horizon] = [];
+    recentChanges[c.horizon].push(c);
+  }
+}
+
+// "What moved this month" headline. Generates one-line prose from the
+// last 30 days of changes, up to 3 clauses, with "+ N more" suffix if
+// more exist. Empty fallback conveys honest stillness.
+function formatDelta(months: number): string {
+  const abs = Math.abs(months);
+  const dir = months > 0 ? 'pushed back' : 'pulled in';
+  if (abs < 12) return `${dir} ${abs} mo`;
+  const yrs = Math.round(abs / 12);
+  return `${dir} ${yrs} yr${yrs === 1 ? '' : 's'}`;
+}
+
+function topicFor(id: string): string {
+  const s = scenarios.find((x) => x.id === id);
+  return s ? s.topic : id.replace('scenario-', '').replace(/-/g, ' ');
+}
+
+const flatChanges: ShiftChange[] = recentScenarioShifts.flatMap((s) => s.changes!);
+let headline: string;
+if (flatChanges.length === 0) {
+  headline = 'No scenario drift this month — consensus holding.';
+} else {
+  const clauses = flatChanges.slice(0, 3).map((c) => {
+    const topic = topicFor(c.horizon);
+    if (c.delta_months != null && c.from != null && c.to != null) {
+      return `${topic} ${c.stance} ${formatDelta(c.delta_months)}`;
+    }
+    return `${topic} ${c.stance} band change`;
+  });
+  let line = `This month: ${clauses.join('; ')}`;
+  if (flatChanges.length > 3) line += `; + ${flatChanges.length - 3} more`;
+  line += '.';
+  headline = line;
+}
+
+const currentYear = new Date().getUTCFullYear();
+---
+
+<BaseLayout
+  title="Five Horizons"
+  description="Arrival-year forecasts for five AI futures across three worldviews — optimistic, pragmatic, sceptical. A living consensus map of when transformative AI reshapes work, robotics, software, and education."
+>
+  <section class="min-h-screen bg-void text-text-bright pt-8 pb-16">
+    <div class="px-4 sm:px-6 lg:px-8 max-w-[1600px] mx-auto">
+      <!-- Hero -->
+      <div class="flex items-start justify-between gap-4 mb-1 flex-wrap">
+        <h1
+          class="font-mono font-bold text-neon-green glow-green"
+          style="font-size: clamp(28px, 4vw, 44px); letter-spacing: 0.04em;"
+        >
+          FIVE HORIZONS
+        </h1>
+        <a
+          href="/horizon"
+          class="font-mono text-xs text-text-muted hover:text-neon-cyan transition-colors self-center"
+        >
+          ← Horizon Map
+        </a>
+      </div>
+      <p class="font-mono text-xs text-text-muted mb-6 max-w-3xl">
+        Where consensus sits across the five AI futures we track. Three dots per row:
+        optimistic, pragmatic, sceptical. Near-term detail, far-future zones.
+      </p>
+
+      <!-- What moved headline -->
+      <p
+        class="font-mono text-sm mb-8 pb-5 border-b border-surface-light"
+        style="color: var(--color-neon-cyan, #5ab8d4);"
+      >
+        <span class="text-neon-amber">◂</span> {headline}
+      </p>
+
+      <!-- The Strip -->
+      <HorizonStrip
+        client:visible
+        scenarios={scenarios}
+        events={events}
+        recentChanges={recentChanges}
+        currentYear={currentYear}
+      />
+
+      <!-- Live ticker (scenarios shift log, scrolling) -->
+      {flatChanges.length > 0 && (
+        <div class="mt-10 pt-5 border-t border-surface-light overflow-hidden">
+          <div class="font-mono text-[11px] uppercase tracking-widest text-text-muted mb-2">
+            recent drift
+          </div>
+          <div class="overflow-hidden whitespace-nowrap relative" style="height: 24px;">
+            <div
+              class="inline-block font-mono text-xs text-text-muted"
+              style="animation: horizon-ticker 60s linear infinite; padding-left: 100%;"
+            >
+              {flatChanges.map((c, i) => (
+                <span class="mx-6">
+                  <span class="text-neon-amber">◂</span>{' '}
+                  <span class="text-text-bright">{topicFor(c.horizon)}</span>{' '}
+                  {c.stance}
+                  {c.from != null && c.to != null && (
+                    <> {c.from} → {c.to}</>
+                  )}
+                  {c.delta_months != null && (
+                    <> ({formatDelta(c.delta_months)})</>
+                  )}
+                </span>
+              ))}
+            </div>
+          </div>
+          <style>{`
+            @keyframes horizon-ticker {
+              from { transform: translateX(0); }
+              to { transform: translateX(-100%); }
+            }
+          `}</style>
+        </div>
+      )}
+
+      <!-- Footer strip: back link + source -->
+      <div class="mt-12 pt-5 border-t border-surface-light flex items-center justify-between gap-3 flex-wrap">
+        <a
+          href="/horizon"
+          class="font-mono text-sm text-neon-cyan hover:underline"
+        >
+          ← Back to Horizon Map
+        </a>
+        <span class="font-mono text-[11px] text-text-muted">
+          Data: <code class="text-text-bright">src/data/horizon/scenarios.json</code>
+          · Bot-enriched drift since <code class="text-text-bright">{cutoffISO}</code>
+        </span>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary

- New **`/horizon/five`** page: single-chart synthesis of the five scenario triplets, banded axis (NEAR/MID/FAR/INDEFINITE), massive mono row labels, confidence envelopes, ghost dots + drift arrows, event markers, scrolling drift ticker. Entered via a hero-area button on `/horizon` (no nav link — intentional destination).
- **Data model expansion:** `year` + `band` on each of 15 stance blocks, `definition` + `contested` + `debate_ref` per scenario, plus a new `debate-what-counts-as-agi` entry to back AGI's contested flag.
- **Bot enrichment:** `horizon_bot.py` shift-gen now diffs `scenarios.json` when a commit touches it and attaches a `changes` array to the shift entry — feeds the "what moved this month" headline, dot tooltips, and ghost-drift visualisation. 10 failure modes handled.

## What ships

| Area | File | Change |
|---|---|---|
| Data | `src/data/horizon/scenarios.json` | 15 years + 5 definitions + AGI contested + debate_ref |
| Data | `src/data/horizon/debates.json` | new `debate-what-counts-as-agi` |
| Schema | `src/content.config.ts` | horizonScenarios extended, banded-axis types |
| Validator | `scripts/validate-horizon-refs.mjs` | year range, band enum, definition length, debate_ref resolution, changes-array schema |
| Helper | `src/lib/horizon-axis.ts` | NEW — yearToBand, yearToX, dotCollisionOffsets |
| Component | `src/components/HorizonStrip.tsx` | NEW — Preact island, full-bleed SVG, banded axis, envelopes, ghost dots + arrows, event markers, SVG a11y, tap-pin tooltip, scroll affordance |
| Page | `src/pages/horizon/five.astro` | NEW — hero, "what moved" headline, strip, ticker, back-link |
| Page | `src/pages/horizon.astro` | hero button, cross-page anchors, definitions on Compare View cards |
| Bot | `bot/horizon_bot.py` | `parse_scenario_diff`, `enrich_scenario_shifts`, `scenario_changes_parsed` counter |

## Design intent

- **Banded axis** gives NEAR (2026–2030) full per-year precision, MID (2031–2035) 2-year buckets, FAR (2036–2045) rough zones, and a pinned "indefinite" column for "not this generation" claims. Reader-model decision: near-term disagreement matters more for decisions, so it gets the screen real estate.
- **Visual-first page:** full-bleed, massive mono typography per row, ghost dots + arrows for drift, live-ticker feel at the bottom. Text is on-demand (hover/tap-pin tooltip + row-label overlay), not baseline.
- **Cross-page deep link:** chart dots → `/horizon#scenario-<slug>` anchor jumps to the supporting Compare View card. Scenario cards now render the `definition` prose at top and a ⚠ contested glyph with a debate link.

## Reviews baked in

- **CEO review** (`/plan-ceo-review`, SCOPE_EXPANSION): 14 proposals, 14 accepted, 5 deferred to TODOS. Plan persisted at `~/.gstack/projects/valorifutures-softcat.ai/ceo-plans/2026-04-22-five-horizons.md`.
- **Eng review** (`/plan-eng-review`, FULL_REVIEW): 1 issue resolved (helper placement → `src/lib/horizon-axis.ts`), 25-path test coverage diagram, 0 critical gaps.
- **Outside voice** (Claude subagent): 5 findings integrated — scenario-card anchors and `debate_ref` restored, bot failure-map expanded, contested-glyph dangling-signal fixed.
- **Design review:** informal pass 7/10. Formal `/design-review` (visual QA) recommended post-deploy.

## Test plan

- [ ] Pull the branch, run `npm install && npm run build` — must exit 0 (already verified locally, 548 pages, 5s)
- [ ] Run `node scripts/validate-horizon-refs.mjs` — must report `53 entries, 0 error(s), 0 warning(s)`
- [ ] `npm run dev`, visit `http://localhost:4321/horizon/five`:
  - [ ] All 5 row labels render (AGI / AGENTIC WORK / ROBOTICS / SOFTWARE AUTOMATION / EDUCATION DISRUPTION)
  - [ ] 15 dots placed in correct bands (AGI pragmatic in MID, Education sceptical in INDEFINITE column)
  - [ ] Load animation: dots sweep in from left
  - [ ] Hover a dot → tooltip with horizon, stance, timeframe, implication
  - [ ] Click a dot → cross-page navigation to `/horizon#scenario-<slug>` lands on the matching card
  - [ ] Hover AGI row label → definition overlay with ⚠ contested + "See debate →" link
  - [ ] AGI row shows ⚠ glyph near the label
  - [ ] Education sceptical renders as an outlined square (indefinite glyph), not a filled circle
  - [ ] Confidence envelope band visible behind each row's dots
  - [ ] "Consensus holding" empty-state headline reads honestly (no drift yet)
  - [ ] Back link returns to `/horizon` hero
- [ ] Visit `/horizon`:
  - [ ] Hero-area "Five Horizons" button appears below the past/now/next stats
  - [ ] Each Compare View scenario card renders the `definition` prose at top
  - [ ] AGI card shows ⚠ with "See debate →" link that jumps to the new debate entry
  - [ ] Clicking a dot on `/horizon/five` lands on the correct Compare View card
- [ ] Keyboard: Tab through chart dots, Enter/Space navigates to scenario card
- [ ] Mobile (<600px): chart horizontal-scrolls, "scroll →" affordance visible at right edge
- [ ] After merge, first manual edit to `scenarios.json` triggers the bot to emit a `changes` array — verify by running horizon_bot locally or checking the next daily run

## Not in scope (deferred to TODOs)

- Horizon bot drift-proposal job (new 4th job, PR per proposed year shift) — gate: 2–3 months of manual edits
- Historical compare slider — gate: 3+ months of shift history
- OG image generation for `/horizon/five`
- Data-table accessibility toggle
- Mobile vertical-transpose variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)