### PR TITLE
fix(horizon): Five Horizons polish — visible row labels, stronger axis, richer hero

### DIFF
--- a/src/components/HorizonStrip.tsx
+++ b/src/components/HorizonStrip.tsx
@@ -77,12 +77,16 @@ const STANCE_LABEL: Record<Stance, string> = {
   sceptical: 'sceptical',
 };
 
+// SVG <text> is painted via the `fill` property, not `color`. Using
+// `text-neon-*` here sets CSS `color` only and leaves fill at the SVG
+// default (black) — which is invisible on the void background. These
+// utilities target fill directly so the massive row labels actually show.
 const ROW_ACCENT_CLASS: Record<ScenarioForStrip['accent'], string> = {
-  green: 'text-neon-green',
-  cyan: 'text-neon-cyan',
-  purple: 'text-neon-purple',
-  amber: 'text-neon-amber',
-  red: 'text-neon-red',
+  green: 'fill-neon-green',
+  cyan: 'fill-neon-cyan',
+  purple: 'fill-neon-purple',
+  amber: 'fill-neon-amber',
+  red: 'fill-neon-red',
 };
 
 // Short chart labels. The full scenario.topic would overflow the 240px label
@@ -232,8 +236,8 @@ export default function HorizonStrip({
                   x={x + w / 2}
                   y={chartTop - 12}
                   text-anchor="middle"
-                  class="font-mono fill-text-muted"
-                  style="font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase;"
+                  class="font-mono fill-text-bright"
+                  style="font-size: 11px; letter-spacing: 0.25em; text-transform: uppercase;"
                 >
                   {band === 'indefinite' ? 'indefinite' : band}
                 </text>
@@ -281,16 +285,17 @@ export default function HorizonStrip({
                   x1={x}
                   x2={x}
                   y1={chartTop + chartH}
-                  y2={chartTop + chartH + 4}
-                  stroke="var(--color-text-muted, #6b7280)"
+                  y2={chartTop + chartH + 6}
+                  stroke="var(--color-text-bright, #e5e7eb)"
                   stroke-width="1"
+                  opacity="0.7"
                 />
                 <text
                   x={x}
-                  y={chartTop + chartH + 34}
+                  y={chartTop + chartH + 36}
                   text-anchor="middle"
-                  class="font-mono fill-text-muted"
-                  style="font-size: 10px;"
+                  class="font-mono fill-text-bright"
+                  style="font-size: 11px;"
                 >
                   {display ?? year}
                 </text>
@@ -301,10 +306,10 @@ export default function HorizonStrip({
           {/* Indefinite column header */}
           <text
             x={LABEL_COL_W + zoneStartX('indefinite', axis) + axis.widths.indefinite / 2}
-            y={chartTop + chartH + 34}
+            y={chartTop + chartH + 36}
             text-anchor="middle"
-            class="font-mono fill-text-muted"
-            style="font-size: 10px;"
+            class="font-mono fill-text-bright"
+            style="font-size: 11px;"
           >
             ???
           </text>

--- a/src/pages/horizon/five.astro
+++ b/src/pages/horizon/five.astro
@@ -173,10 +173,36 @@ const currentYear = new Date().getUTCFullYear();
           ← Horizon Map
         </a>
       </div>
-      <p class="font-mono text-xs text-text-muted mb-6 max-w-3xl">
-        Where consensus sits across the five AI futures we track. Three dots per row:
-        optimistic, pragmatic, sceptical. Near-term detail, far-future zones.
-      </p>
+      <div class="font-mono text-xs text-text-muted mb-6 max-w-3xl space-y-2 leading-relaxed">
+        <p>
+          Where consensus sits across the five AI futures we track. Three dots
+          per horizon: <span class="text-neon-green">optimistic</span>,
+          <span class="text-neon-cyan">pragmatic</span>,
+          <span class="text-neon-red">sceptical</span>. The horizontal axis is
+          non-uniform: the <span class="text-text-bright">NEAR</span> zone gets
+          per-year detail because that's where real decisions get made;
+          <span class="text-text-bright">MID</span> and
+          <span class="text-text-bright">FAR</span> zones collapse to bands
+          because forecasting precision a decade out is dishonest;
+          <span class="text-text-bright">INDEFINITE</span> (far right) holds
+          claims that may not happen this generation.
+        </p>
+        <p>
+          <span class="text-neon-amber">Hover a row name</span> for a crisp
+          definition of that horizon (AGI is contested — follow the
+          <span class="text-neon-amber">⚠</span> to the debate).
+          <span class="text-neon-amber">Hover a dot</span> for the full stance
+          and its implication.
+        </p>
+        <p>
+          The view is <span class="text-text-bright">dynamic</span>: the axis
+          anchors to the current year, so zones slide forward as time passes
+          (what's NEAR today becomes MID next year). Horizon shifts land here
+          as the bot narrates each update in the ticker below and as
+          <span class="text-text-bright">ghost dots + arrows</span> on any row
+          whose stance has moved in the last 30 days.
+        </p>
+      </div>
 
       <!-- What moved headline -->
       <p


### PR DESCRIPTION
## Summary

Fixes three issues raised on first live look at https://softcat.ai/horizon/five/:

- **Row labels were rendering pure black** (`fill: rgb(0,0,0)`) on the void background — invisible. SVG `<text>` paints via `fill`, not `color`, so the `text-neon-*` Tailwind utilities set CSS `color` and left `fill` at the SVG default. Fix: `ROW_ACCENT_CLASS` now uses `fill-neon-*`. AGI renders amber, AGENTIC cyan, ROBOTS purple, SW AUTO green, EDUCATION red.
- **Axis labels were not visible enough.** Zone headers and year ticks were `fill-text-muted` at 10px — legible close-up but dim against void. Bumped to `fill-text-bright` at 11px with wider letter-spacing.
- **Hero explainer was too thin.** One dense line expanded to three short paragraphs: (a) what the non-uniform axis is and why NEAR gets per-year detail, (b) how to interact (hover row for definition, hover dot for stance, follow the ⚠ on AGI for the contested-definition debate), (c) the dynamic nature — bands slide forward with time, ghost dots + arrows land when the bot narrates any scenario drift in the last 30 days.

## Before / after

Row label computed fills pre-fix: all `rgb(0, 0, 0)` — invisible.
Post-fix: amber, cyan, purple, green, red — the colours the chart was always meant to have.

## Test plan

- [ ] `npm run build` green (already verified: 548 pages, 4.4s)
- [ ] Load `/horizon/five` — all 5 row labels now pop in neon colours
- [ ] Axis year ticks (2026, 2027, 2028, 2029, 2030, 2031-2035, 2036+) all clearly visible
- [ ] Zone headers NEAR, MID, FAR, INDEFINITE visible above chart
- [ ] Hero has three paragraphs of context
- [ ] AGI row still shows ⚠ glyph and links to `#debate-what-counts-as-agi`
- [ ] No regression on dot placement, confidence envelopes, or tooltips

## Follow-ups

- None. The "floating widget" visible in some screenshots is a headless browser artifact (confirmed not in page DOM) and does not ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)