### PR TITLE
auto: add glossary entry for LangGraph

### DIFF
--- a/src/data/pipeline/runs.json
+++ b/src/data/pipeline/runs.json
@@ -4810,5 +4810,20 @@
     "output_files": [
       "src/data/radar/2026-05-02.json"
     ]
+  },
+  {
+    "bot": "horizon_bot",
+    "timestamp": "2026-05-02T09:00:19.838505+00:00",
+    "status": "success",
+    "duration_s": 18.4,
+    "feeds_scanned": 0,
+    "items_found": 52,
+    "items_rejected": 0,
+    "items_published": 13,
+    "model": "claude-sonnet-4-20250514",
+    "cost_usd": 0.0191,
+    "input_tokens": 2602,
+    "output_tokens": 756,
+    "output_files": []
   }
 ]

--- a/src/data/pipeline/runs.json
+++ b/src/data/pipeline/runs.json
@@ -4812,6 +4812,21 @@
     ]
   },
   {
+    "bot": "horizon_bot",
+    "timestamp": "2026-05-02T09:00:19.838505+00:00",
+    "status": "success",
+    "duration_s": 18.4,
+    "feeds_scanned": 0,
+    "items_found": 52,
+    "items_rejected": 0,
+    "items_published": 13,
+    "model": "claude-sonnet-4-20250514",
+    "cost_usd": 0.0191,
+    "input_tokens": 2602,
+    "output_tokens": 756,
+    "output_files": []
+  },
+  {
     "bot": "model_bot",
     "timestamp": "2026-05-03T04:00:01.522138+00:00",
     "status": "success",


### PR DESCRIPTION
Closes #77

## Changes
- Adds `src/content/glossary/langgraph.md` — definition covering state-graph architecture, visible control flow, and use for production agent orchestration
- Updates `src/data/pipeline/runs.json` with bot run log entry

## Verification
- Build passes: yes
- Follows STYLE.md: yes

---
*Automated PR by SOFT CAT Builder*