### PR TITLE
ci: add PR build validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: Validate PR build
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate.yml`, which runs `npm ci` + `npm run build` on every PR targeting `main`.
- Catches Astro/Zod schema violations at PR time, before they can break `main` and block the deploy.

## Why now

PR #140 (horizon_bot proposals, 2026-05-09) shipped two `now.json` entries with IDs in the form `now-YYYY-MM-DD-slug` instead of the schema's required `now-YYYY-MM-slug`. The bad IDs only failed at the Astro content-collection build step, which today only runs **after** merge — so `main` broke twice in a row before being hot-fixed in f212c30.

A PR-level build is the smallest change that closes that gap. It mirrors the `deploy.yml` build job (same Node 24, same `npm ci && npm run build`) but on `pull_request` instead of `push`, so the same failure on a future bot PR would surface red on the PR before merge.

## Scope

Deliberately minimum:

- Does **not** touch `deploy.yml` (CLAUDE.md rule #3).
- Does **not** wire `scripts/validate-horizon-refs.mjs` into CI yet — that's a separate v1.5 hardening item and can ship later if dangling refs become a real problem.
- Does **not** change horizon_bot or the Zod schemas.

## Test plan

- [ ] Workflow appears under Actions on this PR
- [ ] `Validate PR build / build` runs and goes green on this PR (this PR adds no JSON content, so the build should pass)
- [ ] Confirm the same workflow would have failed on a synthetic PR with a `now-2026-05-09-foo` ID (manual sanity check, optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)