### PR TITLE
radar: archive footprint + bot push reliability (TODOS #7, #8, #9)

### DIFF
--- a/bot/radar_bot.py
+++ b/bot/radar_bot.py
@@ -307,15 +307,45 @@ Keep discord_summary under 1800 characters. Wrap all URLs in angle brackets.
     return data, response.usage
 
 
+def _git(args: list[str], check: bool = False):
+    """Run a git command in the repo, capturing output."""
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=check)
+
+
+def prune_orphan_files(manifest: dict) -> list[str]:
+    """Delete radar day-files on disk that the manifest no longer references.
+
+    The manifest is capped to MAX_ARCHIVE_DAYS, so any ????-??-??.json file whose
+    date isn't in manifest['dates'] is either an orphan left by an earlier run or
+    has aged out of the cap. Radar entries worth keeping are copied canonically
+    into past.json by the horizon bot before they age out, so removing the source
+    file here is safe. Deletions are staged via `git rm` so they ride along in the
+    same commit as the new day's data.
+    """
+    keep = set(manifest.get("dates", []))
+    removed = []
+    for f in sorted(RADAR_DIR.glob("????-??-??.json")):
+        if f.stem in keep:
+            continue
+        _git(["rm", "--quiet", "--ignore-unmatch", str(f)])
+        if f.exists():  # untracked file: git rm left it on disk, remove directly
+            f.unlink()
+        removed.append(f.name)
+    if removed:
+        print(f"Pruned {len(removed)} orphan radar file(s): {', '.join(removed)}")
+    return removed
+
+
 def save_and_push(radar_data: dict, history: dict):
-    """Save radar JSON, update manifest, commit and push."""
+    """Save radar JSON, update manifest, prune orphans, commit and push.
+
+    We commit locally *before* syncing with the remote so today's radar data is
+    captured in a real commit straight away. A failed remote sync then can't
+    strand the day's output in a stash (the old `git stash pop` crash on a dirty
+    runs.json from a concurrent bot); the already-committed data is recovered by
+    the next successful run or a manual push.
+    """
     os.chdir(REPO_DIR)
-    # Stash any dirty files (e.g. runs.json from other bots) so rebase can proceed
-    stash_result = subprocess.run(["git", "stash", "--include-untracked"], capture_output=True, text=True)
-    stashed = "No local changes" not in stash_result.stdout
-    subprocess.run(["git", "pull", "--rebase"], check=True)
-    if stashed:
-        subprocess.run(["git", "stash", "pop"], check=True)
 
     today = date.today().isoformat()
     filename = f"{today}.json"
@@ -335,6 +365,9 @@ def save_and_push(radar_data: dict, history: dict):
     save_manifest(manifest)
     print(f"Manifest updated: {len(manifest['dates'])} dates")
 
+    # Drop day-files that aged out of the manifest or were orphaned earlier
+    prune_orphan_files(manifest)
+
     # Update history
     product_names = [p["name"] for p in radar_data.get("featured", [])]
     product_names += [p["name"] for p in radar_data.get("picks", [])]
@@ -345,25 +378,45 @@ def save_and_push(radar_data: dict, history: dict):
     })
     save_history(history)
 
-    # Git commit and push
-    subprocess.run([
-        "git", "add",
+    # Stage our files (prune_orphan_files already staged any deletions)
+    _git([
+        "add",
         f"src/data/radar/{filename}",
         "src/data/radar/index.json",
         "bot/radar_history.json",
         "src/data/pipeline/runs.json",
-    ], check=True)
+    ])
 
     # Only commit if there are staged changes
-    result = subprocess.run(["git", "diff", "--cached", "--quiet"])
-    if result.returncode == 0:
+    if _git(["diff", "--cached", "--quiet"]).returncode == 0:
         print("No changes to commit.")
         return
 
     msg = f"bot: add radar data ({today})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    subprocess.run(["git", "push"], check=True)
-    print(f"Pushed: {msg}")
+    _git(["commit", "-m", msg], check=True)
+    print(f"Committed: {msg}")
+
+    # Sync with remote and push, retrying if a concurrent bot pushed first.
+    # --autostash handles any stray dirty files (e.g. runs.json) without the old
+    # stash-pop crash. A bounded retry covers the push race between staggered bots.
+    for attempt in range(1, 4):
+        rebase = _git(["pull", "--rebase", "--autostash"])
+        if rebase.returncode != 0:
+            print(f"[radar_bot] rebase failed (attempt {attempt}):\n{rebase.stderr.strip()}")
+            _git(["rebase", "--abort"])
+            time.sleep(3)
+            continue
+        push = _git(["push"])
+        if push.returncode == 0:
+            print(f"Pushed: {msg}")
+            return
+        print(f"[radar_bot] push rejected (attempt {attempt}):\n{push.stderr.strip()}")
+        time.sleep(3)
+
+    raise RuntimeError(
+        "radar_bot: could not push after 3 attempts. Today's radar data is "
+        "committed locally and will be pushed on the next successful run."
+    )
 
 
 def post_to_discord(radar_data: dict):

--- a/bot/thoughts_history.json
+++ b/bot/thoughts_history.json
@@ -429,6 +429,11 @@
       "date": "2026-05-20",
       "file": "2026-05-20-programming-languages-just-became-middleware-for-ai-compiler.md",
       "title": "Programming languages just became middleware for AI compilers"
+    },
+    {
+      "date": "2026-05-21",
+      "file": "2026-05-21-forward-deployed-engineers-are-just-consultants-with-better-.md",
+      "title": "Forward deployed engineers are just consultants with better marketing"
     }
   ]
 }

--- a/src/content/thoughts/2026-05-21-forward-deployed-engineers-are-just-consultants-with-better-.md
+++ b/src/content/thoughts/2026-05-21-forward-deployed-engineers-are-just-consultants-with-better-.md
@@ -1,0 +1,24 @@
+---
+title: "Forward deployed engineers are just consultants with better marketing"
+date: 2026-05-21
+tags: [forward-deployment, enterprise-ai, consulting]
+summary: "The hottest AI job title is just repackaging what McKinsey has done for decades."
+draft: false
+pinned: false
+---
+
+Tech companies are falling over themselves to hire "forward deployed engineers" for their enterprise AI pushes. OpenAI's $4B deployment arm, Anthropic's joint ventures, Google's enterprise plays. They've discovered the revolutionary concept of sending technical people to customer sites to solve problems. Except this isn't revolutionary at all.
+
+## Palantir didn't invent field engineering
+
+Forward deployment sounds cutting-edge until you realise it's just consulting with a Silicon Valley rebrand. McKinsey, Accenture, and IBM have been dropping technical teams into Fortune 500s for decades. The only difference is that now we're calling it "AI implementation" instead of "digital transformation" and the consultants actually know how to code.
+
+The reason this model works for AI isn't because it's innovative. It's because enterprise software integration has always been a mess that requires humans to fix. LLMs just made the mess more expensive and the fixes more opaque.
+
+## Why SaaS falls apart for enterprise AI
+
+Standard software-as-a-service assumes your product works the same way for everyone. But enterprise AI is the opposite of standardised. Every company's data is different, their workflows are different, their compliance requirements are different. You can't package "intelligence" into a neat API and expect it to work out of the box.
+
+So companies are rediscovering that complex technical problems need people on-site to solve them. Revolutionary.
+
+The real skill isn't being a "forward deployed engineer". It's being good enough at both technology and people to make AI work in organisations that barely understand what they've bought.

--- a/src/data/pipeline/runs.json
+++ b/src/data/pipeline/runs.json
@@ -6474,5 +6474,22 @@
     "output_files": [
       "src/content/news-and-updates/2026-05-21-ai-digest.md"
     ]
+  },
+  {
+    "bot": "thoughts_bot",
+    "timestamp": "2026-05-21T07:00:20.955973+00:00",
+    "status": "success",
+    "duration_s": 19.5,
+    "feeds_scanned": 5,
+    "items_found": 57,
+    "items_rejected": 0,
+    "items_published": 1,
+    "model": "claude-sonnet-4-20250514",
+    "cost_usd": 0.0225,
+    "input_tokens": 5356,
+    "output_tokens": 427,
+    "output_files": [
+      "src/content/thoughts/2026-05-21-forward-deployed-engineers-are-just-consultants-with-better-.md"
+    ]
   }
 ]

--- a/src/pages/radar/[date].astro
+++ b/src/pages/radar/[date].astro
@@ -16,9 +16,10 @@ const visibleDates = manifest.dates.slice(0, RADAR_VISIBLE_DAYS);
 
 const { date } = Astro.params;
 
-const allDayFiles = import.meta.glob('../../data/radar/????-??-??.json', { eager: true });
-const dayKey = Object.keys(allDayFiles).find((k) => k.includes(date));
-const dayData = dayKey ? (allDayFiles[dayKey] as any).default : null;
+// Lazy glob: only this date's file is read at build, not the entire archive.
+const dayFiles = import.meta.glob('../../data/radar/????-??-??.json');
+const dayKey = Object.keys(dayFiles).find((k) => k.includes(date));
+const dayData = dayKey ? ((await dayFiles[dayKey]()) as any).default : null;
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr + 'T00:00:00Z');

--- a/src/pages/radar/index.astro
+++ b/src/pages/radar/index.astro
@@ -5,9 +5,11 @@ import RadarPickCard from '../../components/RadarPickCard.astro';
 
 import manifest from '../../data/radar/index.json';
 
-const allDayFiles = import.meta.glob('../../data/radar/????-??-??.json', { eager: true });
-const latestKey = Object.keys(allDayFiles).find((k) => k.includes(manifest.latest));
-const dayData = latestKey ? (allDayFiles[latestKey] as any).default : null;
+// Lazy glob: only the latest day's file is read at build, not the entire
+// on-disk archive (which the bot keeps up to MAX_ARCHIVE_DAYS for the horizon bot).
+const dayFiles = import.meta.glob('../../data/radar/????-??-??.json');
+const latestKey = Object.keys(dayFiles).find((k) => k.includes(manifest.latest));
+const dayData = latestKey ? ((await dayFiles[latestKey]()) as any).default : null;
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr + 'T00:00:00Z');

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import radarManifest from '../data/radar/index.json';
+import { RADAR_VISIBLE_DAYS } from '../utils/radar';
 
 export const GET: APIRoute = async () => {
   const [news, thoughts, tools, prompts] = await Promise.all([
@@ -61,19 +62,25 @@ export const GET: APIRoute = async () => {
     });
   }
 
-  // Load radar data
-  const radarFiles = import.meta.glob('../data/radar/????-??-??.json', { eager: true });
-  for (const [path, mod] of Object.entries(radarFiles)) {
-    const data = (mod as any).default;
-    const items = [...(data.featured || []), ...(data.picks || [])];
+  // Load radar data, bounded to the visible window. Older day-files stay on
+  // disk for the horizon bot but have no public /radar/<date> route, so indexing
+  // them would point search results at pages that 404. Lazy glob keeps the build
+  // from reading the entire archive into memory.
+  const radarFiles = import.meta.glob('../data/radar/????-??-??.json');
+  const visibleDates = radarManifest.dates.slice(0, RADAR_VISIBLE_DAYS);
+  for (const date of visibleDates) {
+    const key = Object.keys(radarFiles).find((k) => k.includes(date));
+    if (!key) continue;
+    const data = (await radarFiles[key]()) as any;
+    const items = [...(data.default.featured || []), ...(data.default.picks || [])];
     for (const item of items) {
       entries.push({
         title: item.name,
         summary: item.tagline || item.why_radar || '',
-        url: `/radar/${data.date}`,
+        url: `/radar/${data.default.date}`,
         type: 'radar',
         tags: item.category ? [item.category] : [],
-        date: data.date,
+        date: data.default.date,
       });
     }
   }


### PR DESCRIPTION
Addresses **TODOS.md items #7, #8, #9** — note these are TODOS.md item numbers, **not** GitHub issue numbers (GitHub #7/#8/#9 are unrelated, already closed/merged).

## Bot reliability — TODOS #9 (fragile `git stash pop` under concurrent CI)
`save_and_push` now commits today's radar data locally **before** syncing with the remote, so a failed sync can't strand output in a stash. The old stash/pop dance crashed on a dirty `runs.json` written by a concurrent bot. Replaced with `git pull --rebase --autostash` plus a bounded 3-attempt push retry to cover the push race between staggered bots. If all attempts fail, the day's data is already committed locally and recovered by the next successful run.

## Archive footprint — TODOS #7 (orphan accumulation) & #8 (eager glob)
- `prune_orphan_files` drops day-files that aged out of the manifest (capped at `MAX_ARCHIVE_DAYS=365`) or were orphaned by an earlier run, staged via `git rm` so deletions ride the same commit.
- `radar/[date].astro` and `radar/index.astro` switch from eager to **lazy** `import.meta.glob` — the build reads only the file(s) it needs, not the whole on-disk archive.
- `search-index.json.ts` bounds radar entries to the visible window (`RADAR_VISIBLE_DAYS=30`), so search never links to older day-files that have no public route.

## Verification
- `npm run build` ✓ (718 pages, no errors)
- `python3 -m py_compile bot/radar_bot.py` ✓
- Confirmed all referenced symbols in scope (`time`, `subprocess`, `RADAR_DIR`, `MAX_ARCHIVE_DAYS`, `RADAR_VISIBLE_DAYS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)