### PR TITLE
horizon validator: hard-fail confidence_last_reviewed at 180 days (TODOS #1)

### DIFF
--- a/scripts/validate-horizon-refs.mjs
+++ b/scripts/validate-horizon-refs.mjs
@@ -11,7 +11,7 @@
 //   4. Debate `for.supporting` / `against.supporting` resolve to a known id.
 //   5. Scenario `related[]` resolves to a known id.
 //   6. Next-lane `confidence_last_reviewed` older than 90 days produces a
-//      warning (TODOS.md #1 tracks future escalation to hard-fail at 180d).
+//      warning; older than 180 days is an error (TODOS.md #1).
 //
 // Errors fail the run (exit 1). Warnings do not.
 
@@ -27,6 +27,11 @@ const THOUGHTS_DIR = join(ROOT, 'src/content/thoughts');
 const NEWS_DIR = join(ROOT, 'src/content/news-and-updates');
 
 const WARN_DAYS = 90;
+// TODOS #1: stale forecasts on a forecasting page are a credibility hit. v1
+// shipped warn-only at 90d while editorial cadence calibrated; this escalates
+// to a build failure at 180d. Threshold is tunable — bump it here if a genuine
+// in-transition forecast needs to ship past the limit.
+const FAIL_DAYS = 180;
 
 const errors = [];
 const warnings = [];
@@ -231,7 +236,7 @@ for (let i = 0; i < shifts.length; i++) {
   }
 }
 
-// 6. Next-lane confidence freshness warning.
+// 6. Next-lane confidence freshness: warn at 90d, fail at 180d (TODOS #1).
 const today = new Date();
 today.setUTCHours(0, 0, 0, 0);
 for (const entry of next) {
@@ -239,7 +244,11 @@ for (const entry of next) {
   if (!reviewed) continue;
   const d = new Date(reviewed + 'T00:00:00Z');
   const ageDays = Math.floor((today - d) / 86_400_000);
-  if (ageDays > WARN_DAYS) {
+  if (ageDays > FAIL_DAYS) {
+    errors.push(
+      `next.json: "${entry.id}" confidence_last_reviewed is ${ageDays} days old (> ${FAIL_DAYS}d fail threshold) — re-review the forecast or update the date`,
+    );
+  } else if (ageDays > WARN_DAYS) {
     warnings.push(
       `next.json: "${entry.id}" confidence_last_reviewed is ${ageDays} days old (> ${WARN_DAYS}d warn threshold)`,
     );


### PR DESCRIPTION
Addresses **TODOS.md item #1** (TODOS item number, **not** a GitHub issue). Touches only `scripts/validate-horizon-refs.mjs` — independent of the schema PRs, branched off `main`.

## What
v1 shipped warn-only at 90 days while editorial review cadence was calibrated. This escalates: a Next-lane `confidence_last_reviewed` older than **180 days** now pushes an **error** (exit 1) instead of a warning. The 90-day warning is retained for the 90–180d band. Threshold is a named constant (`FAIL_DAYS`), easy to tune if a genuine in-transition forecast needs to ship past it.

## Verification
- Oldest current `confidence_last_reviewed` is **40 days** → zero entries trip the new rule today (no surprise build breakage).
- Confirmed it bites: injecting a 232-day-old date produces `... is 232 days old (> 180d fail threshold)` (then reverted).

## Notes
- The validator currently still exits 1 because of **25 pre-existing dangling evidence refs** in `now.json` (unrelated to this PR — bot-guessed filenames, tracked separately). This PR's rule is verified independently above.
- The `(TODOS.md #1)` comment in `src/content.config.ts` still calls this a "future" escalation; it'll be refreshed when the schema PRs (#144/#145) and this one land together (housekeeping pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)