### PR TITLE
docs: document horizon bot review surface + prune TODOS.md (TODOS #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,15 @@ The domain is softcat.ai. The GitHub repo is valorifutures/softcat.ai.
 - Pipeline page and activity ticker read runs.json at build time
 - Content frontmatter supports optional pipeline metadata: `generated_by`, `model`, `generation_time_s`, `cost_usd`
 
+## Horizon Map (`/horizon`)
+
+- Data lives in `src/data/horizon/*.json` (lanes: `past`, `now`, `now-archive`, `next`, plus `debates`, `scenarios`, `shifts`). Per-entry shape is enforced by Zod in `src/content.config.ts`; cross-file integrity (id uniqueness, dangling refs, confidence freshness) by `scripts/validate-horizon-refs.mjs`.
+- **Review surface — bot proposes, Valori lands (TODOS #5, decided):**
+  - `bot/horizon_bot.py` Job 1 writes Now-lane proposals to `now.json` on a dated `horizon-bot/proposals-YYYY-MM-DD` branch and opens a **PR**. Valori reviews the data diff and merges to land. The bot never writes `now.json` on `main` directly.
+  - Job 2 (Next confidence shifts) and Job 3 (Past promotion candidates) are **flag-only** — they go to `~/.softcat-bot-staging/horizon-bot-proposals.json` for manual review, not a PR.
+  - `past.json` is single-writer (Valori only). `debates.json` is 100% human-curated.
+- The validator is run manually / via CI, not as part of `astro build`. Run it before merging horizon data PRs: `node scripts/validate-horizon-refs.mjs`.
+
 ## Safety Rules
 
 1. NEVER push directly to main. Always create a branch and PR.

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,21 +2,34 @@
 
 Deferred work surfaced by reviews. Each item has enough context to pick up cold.
 
+Item numbers are stable references (commit messages and PRs cite "TODOS #N"), so
+shipped items are recorded in the ledger below rather than renumbered away.
+
 ---
 
-## 1. Promote `confidence_last_reviewed` warning to hard-fail at 180 days
+## Shipped
 
-**What:** The build-time validator warns when a Next-lane entry's `confidence_last_reviewed` date is older than 90 days. Once editorial review cadence is proven, escalate the validator to **fail the build** at 180 days.
-
-**Why:** v1 starts permissive to avoid false-fail builds while editorial cadence is calibrated. Once you've shown you can re-touch Next entries on a regular cycle, the validator should enforce it. Stale forecasts on a forecasting page are a credibility hit.
-
-**Pros:** Forces sustained editorial discipline. Aligns the schema's promise with the page's actual maintenance.
-
-**Cons:** Premature escalation breaks deploys when you genuinely need to ship while a forecast is in transition.
-
-**Context:** Added by /plan-eng-review on 2026-04-09 (Issue 8 / Outside Voice #6). Schema field is mandatory in v1. Validator behavior is in `scripts/validate-horizon-refs.ts`. The 180-day threshold is a guess; tune after observing real cadence.
-
-**Depends on:** Horizon Map v1 ships. Track 4-8 weeks of editorial review cadence. Decide threshold based on observed median.
+- **#1** — `confidence_last_reviewed` hard-fail at 180 days. Validator now errors
+  (not just warns) past 180d; 90d warning retained for the 90–180d band. (PR #146)
+- **#5** — Human-review surface for bot proposals: chose **bot-opens-PRs**, now
+  documented in CLAUDE.md (Horizon Map section). horizon_bot has opened daily
+  Now-proposal PRs since #112 (2026-04-22); Next flags / Past candidates still go
+  to the `~/.softcat-bot-staging` file. (this housekeeping PR)
+- **#7** — `radar_bot.py` orphan accumulation. `prune_orphan_files` drops
+  day-files that aged out of the manifest, staged via `git rm`. (PR #143)
+- **#8** — Eager `import.meta.glob` in radar pages + search index. Switched to
+  lazy globs; search bounded to the visible window. (PR #143)
+- **#9** — `radar_bot.py` fragile `git stash pop` under concurrent CI. Now commits
+  before syncing, with `pull --rebase --autostash` + bounded push retry. (PR #143)
+- **#10** — Lane-specific `signal_type` / `confidence` constraints (past/now/next
+  subsets). (PR #145)
+- **#11** — `evidence` / `origin` ref-type alignment: `external` refs must be URLs;
+  `origin.type` aligned to evidence's full vocabulary (paper/external). (PR #144)
+- **#12** — Relational refines: `updated >= added`, `confidence_last_reviewed >=
+  added`, debate `supporting.min(1)`. Cross-collection id uniqueness and
+  cross-ref resolution were already covered by `validate-horizon-refs.mjs`.
+  (PR #144) — *residual:* the `radar/[date].astro` missing-day-file build-warning
+  noted in this item's original context is still open (see #13).
 
 ---
 
@@ -68,22 +81,6 @@ Deferred work surfaced by reviews. Each item has enough context to pick up cold.
 
 ---
 
-## 5. Pick the human-review surface for bot proposals
-
-**What:** `horizon_bot.py` writes proposals to `~/.softcat-bot-staging/horizon-bot-proposals.json`. Valori needs a way to review these. Two options on the table: (a) a thin Astro admin page only built locally, or (b) `gh pr` from the bot for the data file diffs. Pick one.
-
-**Why:** Without a clear review surface, proposals pile up in the staging file and never get applied. The whole bot-proposes / human-promotes flow stalls.
-
-**Pros:** Closes the loop on the v1 bot integration. Makes the Past lane self-replenishing.
-
-**Cons:** Both options have real costs. Admin page is more code to maintain. PR-from-bot needs `GITHUB_TOKEN`, `gh` CLI in the bot environment, and a review discipline.
-
-**Context:** Punted in design doc 2026-04-09 (line 224) to "week 2." /plan-eng-review left it as a punt because the choice doesn't affect schema or validator design. Decide once `horizon_bot.py` has actually generated its first batch of real proposals — the volume and shape of those proposals will make the choice obvious.
-
-**Depends on:** Step 6 of v1 sequence (horizon_bot.py first run produces proposals).
-
----
-
 ## 6. Theme enum rebalance after 50+ entries
 
 **What:** The horizon `Theme` enum has 16 values (`models`, `agents`, `robotics`, `interfaces`, `search`, `code`, `data`, `infrastructure`, `chips`, `regulation`, `security`, `enterprise`, `work`, `education`, `creativity`, `society`). At v1 launch with ~50 entries, distribution is unknown. Once the page hits 50+ entries, audit the distribution: some themes will be empty, some will be overloaded.
@@ -100,109 +97,16 @@ Deferred work surfaced by reviews. Each item has enough context to pick up cold.
 
 ---
 
-## 7. No file deletion in `radar_bot.py` — orphan accumulation
+## 13. Build-time warning for radar day-files missing from disk
 
-**What:** `bot/radar_bot.py` never unlinks `src/data/radar/*.json` files. The only retention mechanism is the manifest cap (`MAX_ARCHIVE_DAYS`, line 60), and that just trims the `dates` list inside `index.json`. When the manifest cap was 30 there were already 15 orphaned files on disk (45 files vs 30 manifest entries). With the cap now at 365, the disk grows unbounded forever.
+**What:** `src/pages/radar/[date].astro` resolves the day-file via `import.meta.glob` and sets `dayData = null` when no file matches a manifest date. There is no build-time signal — the page just renders empty. A manifest entry that points at a pruned or never-written day-file should warn (or fail) at build.
 
-**Why:** Eventually this matters. The Astro radar pages and search index use `import.meta.glob` from disk (see TODO 8), so orphaned files affect build time and bundle size even though they're not in the manifest. Long-term this is a death-by-a-thousand-cuts problem: build slower, repo bigger, deploy artifact larger, no single thing that's catastrophic.
+**Why:** Silent empty radar pages are a quiet content failure, especially now that `radar_bot.py` prunes aged-out day-files (#7) — a manifest/disk mismatch is more likely than before.
 
-**Pros:** Bounded disk growth. Faster builds over time. Smaller deploy artifacts. The horizon bot's directory-scan promotion logic (Step 6a) gets a smaller search space.
+**Pros:** Catches manifest/disk drift at build instead of in production.
 
-**Cons:** Deletion is irreversible (well, recoverable from git history but awkward). Needs a clear retention policy: how old before delete, what gets preserved (the `MAX_ARCHIVE_DAYS=365` value defines this). Also: orphaned-but-promoted entries — if a radar file got promoted into `past.json`, can it be safely deleted? Answer is yes (the promoted Past entry is the canonical version) but the logic needs care.
+**Cons:** Small, but needs a decision on warn vs fail. A pruned-but-still-in-manifest date is arguably a data bug worth failing on; a transient race might argue for warn.
 
-**Context:** Surfaced by `/ship` adversarial review on horizon-prereqs (PR #90), 2026-04-10. Pre-existing issue, not caused by the prereqs PR — the cap bump just made the eventual impact larger. The fix is small: add an `unlink_old_files` step in `save_and_push` that deletes files whose date is older than `MAX_ARCHIVE_DAYS` from today, AFTER the manifest is updated. Use `git rm` or `git add` so the deletion lands cleanly.
+**Context:** Split out of #12, where it was folded into the relational-refines batch but not actually addressed. Lives on the radar side, not the horizon schema, so it didn't fit PR #144.
 
-**Depends on:** Decision on retention policy. Probably also: confirmation that the horizon bot's directory-scan logic (Step 6a) is the only consumer that cares about old files.
-
----
-
-## 8. Eager `import.meta.glob` in radar pages and search index loads everything
-
-**What:** `src/pages/radar/index.astro:8`, `src/pages/radar/[date].astro:19`, and `src/pages/search-index.json.ts:65` all use `import.meta.glob('../../data/radar/????-??-??.json', { eager: true })` which loads **every JSON file physically present on disk** at build time, not just files in the manifest. As the radar archive grows (whether from the new 365-day manifest cap or just orphan accumulation), the build's memory footprint, bundle size, and search index file all grow with it.
-
-**Why:** The search index in particular is loaded client-side on Cmd+K. Today it's small. Over a year of accumulating radar entries plus all the other site content, it could grow to several megabytes — slow first-load, slow first search. The radar page builds will also slow proportionally.
-
-**Pros:** Bounded build time. Bounded search index. Bounded memory usage during build.
-
-**Cons:** Two valid fixes — (a) filter the glob results against `manifest.dates.slice(0, RADAR_VISIBLE_DAYS)` so only visible-window files are loaded, or (b) decouple the search index from radar entirely (separate eager glob, separate filter logic). Each requires a small refactor of how the radar pages compose data.
-
-**Context:** Surfaced by `/ship` adversarial review on horizon-prereqs (PR #90), 2026-04-10. This is technically a pre-existing issue but the horizon work makes it more visible because the architectural intent is now "the disk grows for the bot." Note that PR #90 already introduced `RADAR_VISIBLE_DAYS=30` in `src/utils/radar.ts` to bound route generation — extending the same constant to the eager globs is the natural next step.
-
-**Depends on:** Decision on whether the search index should include radar items at all. If yes, what's the cap? `RADAR_VISIBLE_DAYS` or something different?
-
----
-
-## 9. `radar_bot.py` `git stash pop` after `git pull --rebase` is fragile under concurrent CI
-
-**What:** `bot/radar_bot.py:save_and_push` does `git stash --include-untracked` → `git pull --rebase` → `git stash pop` → write → `git add` → `git commit` → `git push`. The `git stash pop` is run with `check=True`, so if it can't reapply cleanly (e.g., the rebase pulled in conflicting changes), the bot crashes and no radar file gets written that day. With CI checkout now using `fetch-depth: 0` (PR #90), every bot push triggers a full-history checkout in the deploy job, widening the window where a bot push can race with the previously-triggered workflow. Pre-existing issue, made marginally more visible by the deploy.yml change.
-
-**Why:** A single failed `git stash pop` results in a missing day in the radar archive. Cumulative reliability matters when the page's whole identity is "the machinery is the story" — a visible gap in the daily output is a credibility hit, even if it's mechanical.
-
-**Pros:** More reliable daily ingestion. Better story for the activity ticker / pipeline page.
-
-**Cons:** The fragility is inherent to mixing untracked-file operations with rebase. Real fix is probably: don't stash, just `git pull --rebase` cleanly; if there are uncommitted local changes, abort and alert (a daily run shouldn't have local uncommitted state). Or use `git fetch` + manual merge instead of pull-rebase.
-
-**Context:** Surfaced by `/ship` adversarial review on horizon-prereqs (PR #90), 2026-04-10. The reviewer rated this 7/10 confidence — the failure mode is real but the trigger requires concurrent runs which is uncommon. Worth fixing once the horizon bot lands and adds another daily push to the same workflow.
-
-**Depends on:** Step 6 of v1 sequence (horizon bot lands and adds a second daily push that could race with the radar bot).
-
----
-
-## 10. Lane-specific `signal_type` / `confidence` constraints
-
-**What:** Today `horizonLaneBase` (`src/content.config.ts`) lets any lane use any `signal_type` (`event`, `trend`, `forecast`, `debate`, `inflection`, `warning`) and any `confidence` (`confirmed`, `emerging`, `contested`, `speculative`). A `past` entry with `signal_type: forecast` validates cleanly. A historical turning point with `confidence: speculative` validates cleanly. Both are nonsense.
-
-**Why:** The schema's job is to encode "what makes sense" so hand-edited or bot-proposed data can't drift into incoherent shapes. Lane-by-lane the meaningful subsets are smaller:
-- past → `signal_type: 'event' | 'inflection'`, `confidence: 'confirmed'`
-- now → `signal_type: 'event' | 'trend' | 'inflection' | 'warning'`, any confidence
-- next → `signal_type: 'forecast'`, any confidence
-
-**Pros:** Catches semantic drift at build time. Clearer intent for any new contributor (the schema documents the meaning of each lane).
-
-**Cons:** Real risk of false-fail. Edge cases: a Past entry that was once `emerging` and is now retrospectively `confirmed` — should the schema allow `confidence: emerging` on past? Probably no (past is the canon). What about a `now` entry that includes a forecast inside it ("X is happening, and it implies Y will follow") — `signal_type: forecast` on now? Probably yes. Not all combinations are obvious.
-
-**Context:** Surfaced by `/ship` testing specialist + adversarial subagent on horizon-schema (PR #91), 2026-04-10. Both reviewers flagged this independently. Deferred from PR #91 because it needs design judgment, not mechanical tightening. The right approach is probably: write down the allowed combinations as a table first, decide each ambiguous case, then encode.
-
-**Depends on:** Real Now / Next / Debates seed data exists (Step 3b–3e of v1 sequence). Without seeing what real entries actually look like, the design decision is too abstract to make well.
-
----
-
-## 11. `evidence.type` / `origin.type` discriminated unions and set alignment
-
-**What:** Two adjacent issues in `src/content.config.ts`:
-
-(a) `horizonEvidence.ref` is a plain string regardless of `type`. A `type: 'radar'` evidence entry should have `ref` matching a radar slug; a `type: 'external'` should have `ref` matching a URL. Today both validate as `z.string().min(1)`.
-
-(b) `horizonOrigin.type` is `'radar' | 'news' | 'thought'`, but `horizonEvidence.type` includes `'paper'` and `'external'` on top. So a Past entry promoted from a paper or external source can't have its origin recorded — the schema rejects it.
-
-**Why:** (a) Catches a real footgun: typing a URL into a `radar`-type ref or vice versa silently ships. (b) Either the inconsistency is intentional (only internal lanes can be promoted to Past) and should be documented, or it's accidental and should be aligned.
-
-**Pros:** Eliminates a class of typos. Forces an explicit decision on whether papers/external sources are valid origins.
-
-**Cons:** Discriminated unions in Zod are slightly more verbose. The (b) decision needs human judgment — is "promoted from a paper" a real workflow we want to support, or is the Past lane strictly downstream of the site's own content?
-
-**Context:** Surfaced by `/ship` adversarial review on horizon-schema (PR #91), 2026-04-10. Both issues are low-impact today because no Now / Past / Next entry currently has any evidence or origin entries. They become real when bot proposals start including provenance.
-
-**Depends on:** First batch of bot-generated promotion proposals (Step 6a of v1 sequence). Real proposals will surface what kinds of provenance are actually being recorded.
-
----
-
-## 12. Small schema relational refines pending the cross-ref validator
-
-**What:** A handful of small schema improvements were deferred from PR #91 because they're either dependent on the build-time validator script (Step 4.5 of v1 sequence) or because they add complexity that's hard to justify before there's real data to validate against:
-
-- `horizonLaneBase`: `.refine(d => !d.updated || d.updated >= d.added)` — catches backdated `updated` timestamps
-- `horizonNext`: `.refine(d => d.confidence_last_reviewed >= d.added)` — catches a `confidence_last_reviewed` set before the entry existed
-- `horizonDebates.for/against.supporting`: `.min(1)` — catches debate sides with no supporting evidence (currently allowed)
-- Cross-collection ID uniqueness — same id can exist in `now.json` AND `now-archive.json`, no schema-level check
-- `related[]`, `evidence.ref`, `origin.ref` cross-reference resolution — typo'd or dangling refs validate at schema level
-
-**Why:** Each one catches a real silent failure. None are blocking until the lanes get seeded with real data.
-
-**Pros:** Schema becomes the canonical definition of "what's valid." Reduces human verification burden on each edit.
-
-**Cons:** The cross-collection and cross-reference checks need a separate validator script (Step 4.5), not Zod, because Zod schemas are per-collection. The relational refines need careful test data to verify they don't false-fail.
-
-**Context:** Surfaced by `/ship` testing specialist + adversarial subagent on horizon-schema (PR #91), 2026-04-10. Deferred together because they're a coherent batch of "tighten once Step 4.5 lands and we have real data." Also worth noting: there's a `dayKey` undefined edge case in `src/pages/radar/[date].astro:21` (when a manifest entry references a missing data file) that should warn at build time — small enough to fold into this batch.
-
-**Depends on:** Step 4.5 of v1 sequence (the cross-ref validator script) lands. Real data exists in at least one of `now.json` / `next.json` / `debates.json` / `scenarios.json` so the refines can be tested against something other than empty arrays.
+**Depends on:** Nothing — can be done any time. Cheap.


### PR DESCRIPTION
Addresses **TODOS.md item #5** and tidies the deferred-work doc after the #1/#7/#8/#9/#10/#11/#12 batch (PRs #143–#146). Docs-only.

## CLAUDE.md — Horizon Map review surface (resolves #5)
Documents the bot→PR flow that's now de facto reality (TODOS #5 asked us to pick a surface; the bot has opened daily proposal PRs since #112):
- `horizon_bot.py` Job 1 opens a dated `horizon-bot/proposals-YYYY-MM-DD` PR for Now entries — **bot proposes, Valori merges to land**, never writes `now.json` on `main` directly.
- Jobs 2/3 (Next confidence flags, Past promotion candidates) are **flag-only** to `~/.softcat-bot-staging`.
- `past.json` single-writer; `debates.json` human-curated.
- Notes the cross-ref validator is a manual/CI gate, not part of `astro build`.

## TODOS.md — prune
- Eight shipped item bodies replaced with a compact **Shipped ledger** mapping each item → its PR.
- **No renumbering** — commits/PRs cite "TODOS #N", so survivors keep their original numbers (#2, #3, #4, #6).
- Split the radar missing-day-file build-warning out of #12 (folded into its context but never actioned) into a new **#13**.

Net: -129 / +42 lines.

> Heads up: this is one of 5 stacked/related PRs. Merge order suggestion: #143 (radar, off main) → #144 (horizon schema, off main) → #145 (lane constraints, **based on #144** — retarget to main after #144 lands) → #146 (validator, off main) → this one. The "Shipped" ledger references all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)