### PR TITLE
radar: archive footprint + push reliability (TODOS #7, #8, #9)

### DIFF
--- a/bot/radar_bot.py
+++ b/bot/radar_bot.py
@@ -307,15 +307,45 @@ Keep discord_summary under 1800 characters. Wrap all URLs in angle brackets.
     return data, response.usage
 
 
+def _git(args: list[str], check: bool = False):
+    """Run a git command in the repo, capturing output."""
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=check)
+
+
+def prune_orphan_files(manifest: dict) -> list[str]:
+    """Delete radar day-files on disk that the manifest no longer references.
+
+    The manifest is capped to MAX_ARCHIVE_DAYS, so any ????-??-??.json file whose
+    date isn't in manifest['dates'] is either an orphan left by an earlier run or
+    has aged out of the cap. Radar entries worth keeping are copied canonically
+    into past.json by the horizon bot before they age out, so removing the source
+    file here is safe. Deletions are staged via `git rm` so they ride along in the
+    same commit as the new day's data.
+    """
+    keep = set(manifest.get("dates", []))
+    removed = []
+    for f in sorted(RADAR_DIR.glob("????-??-??.json")):
+        if f.stem in keep:
+            continue
+        _git(["rm", "--quiet", "--ignore-unmatch", str(f)])
+        if f.exists():  # untracked file: git rm left it on disk, remove directly
+            f.unlink()
+        removed.append(f.name)
+    if removed:
+        print(f"Pruned {len(removed)} orphan radar file(s): {', '.join(removed)}")
+    return removed
+
+
 def save_and_push(radar_data: dict, history: dict):
-    """Save radar JSON, update manifest, commit and push."""
+    """Save radar JSON, update manifest, prune orphans, commit and push.
+
+    We commit locally *before* syncing with the remote so today's radar data is
+    captured in a real commit straight away. A failed remote sync then can't
+    strand the day's output in a stash (the old `git stash pop` crash on a dirty
+    runs.json from a concurrent bot); the already-committed data is recovered by
+    the next successful run or a manual push.
+    """
     os.chdir(REPO_DIR)
-    # Stash any dirty files (e.g. runs.json from other bots) so rebase can proceed
-    stash_result = subprocess.run(["git", "stash", "--include-untracked"], capture_output=True, text=True)
-    stashed = "No local changes" not in stash_result.stdout
-    subprocess.run(["git", "pull", "--rebase"], check=True)
-    if stashed:
-        subprocess.run(["git", "stash", "pop"], check=True)
 
     today = date.today().isoformat()
     filename = f"{today}.json"
@@ -335,6 +365,9 @@ def save_and_push(radar_data: dict, history: dict):
     save_manifest(manifest)
     print(f"Manifest updated: {len(manifest['dates'])} dates")
 
+    # Drop day-files that aged out of the manifest or were orphaned earlier
+    prune_orphan_files(manifest)
+
     # Update history
     product_names = [p["name"] for p in radar_data.get("featured", [])]
     product_names += [p["name"] for p in radar_data.get("picks", [])]
@@ -345,25 +378,45 @@ def save_and_push(radar_data: dict, history: dict):
     })
     save_history(history)
 
-    # Git commit and push
-    subprocess.run([
-        "git", "add",
+    # Stage our files (prune_orphan_files already staged any deletions)
+    _git([
+        "add",
         f"src/data/radar/{filename}",
         "src/data/radar/index.json",
         "bot/radar_history.json",
         "src/data/pipeline/runs.json",
-    ], check=True)
+    ])
 
     # Only commit if there are staged changes
-    result = subprocess.run(["git", "diff", "--cached", "--quiet"])
-    if result.returncode == 0:
+    if _git(["diff", "--cached", "--quiet"]).returncode == 0:
         print("No changes to commit.")
         return
 
     msg = f"bot: add radar data ({today})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    subprocess.run(["git", "push"], check=True)
-    print(f"Pushed: {msg}")
+    _git(["commit", "-m", msg], check=True)
+    print(f"Committed: {msg}")
+
+    # Sync with remote and push, retrying if a concurrent bot pushed first.
+    # --autostash handles any stray dirty files (e.g. runs.json) without the old
+    # stash-pop crash. A bounded retry covers the push race between staggered bots.
+    for attempt in range(1, 4):
+        rebase = _git(["pull", "--rebase", "--autostash"])
+        if rebase.returncode != 0:
+            print(f"[radar_bot] rebase failed (attempt {attempt}):\n{rebase.stderr.strip()}")
+            _git(["rebase", "--abort"])
+            time.sleep(3)
+            continue
+        push = _git(["push"])
+        if push.returncode == 0:
+            print(f"Pushed: {msg}")
+            return
+        print(f"[radar_bot] push rejected (attempt {attempt}):\n{push.stderr.strip()}")
+        time.sleep(3)
+
+    raise RuntimeError(
+        "radar_bot: could not push after 3 attempts. Today's radar data is "
+        "committed locally and will be pushed on the next successful run."
+    )
 
 
 def post_to_discord(radar_data: dict):

--- a/src/pages/radar/[date].astro
+++ b/src/pages/radar/[date].astro
@@ -16,9 +16,10 @@ const visibleDates = manifest.dates.slice(0, RADAR_VISIBLE_DAYS);
 
 const { date } = Astro.params;
 
-const allDayFiles = import.meta.glob('../../data/radar/????-??-??.json', { eager: true });
-const dayKey = Object.keys(allDayFiles).find((k) => k.includes(date));
-const dayData = dayKey ? (allDayFiles[dayKey] as any).default : null;
+// Lazy glob: only this date's file is read at build, not the entire archive.
+const dayFiles = import.meta.glob('../../data/radar/????-??-??.json');
+const dayKey = Object.keys(dayFiles).find((k) => k.includes(date));
+const dayData = dayKey ? ((await dayFiles[dayKey]()) as any).default : null;
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr + 'T00:00:00Z');

--- a/src/pages/radar/index.astro
+++ b/src/pages/radar/index.astro
@@ -5,9 +5,11 @@ import RadarPickCard from '../../components/RadarPickCard.astro';
 
 import manifest from '../../data/radar/index.json';
 
-const allDayFiles = import.meta.glob('../../data/radar/????-??-??.json', { eager: true });
-const latestKey = Object.keys(allDayFiles).find((k) => k.includes(manifest.latest));
-const dayData = latestKey ? (allDayFiles[latestKey] as any).default : null;
+// Lazy glob: only the latest day's file is read at build, not the entire
+// on-disk archive (which the bot keeps up to MAX_ARCHIVE_DAYS for the horizon bot).
+const dayFiles = import.meta.glob('../../data/radar/????-??-??.json');
+const latestKey = Object.keys(dayFiles).find((k) => k.includes(manifest.latest));
+const dayData = latestKey ? ((await dayFiles[latestKey]()) as any).default : null;
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr + 'T00:00:00Z');

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import radarManifest from '../data/radar/index.json';
+import { RADAR_VISIBLE_DAYS } from '../utils/radar';
 
 export const GET: APIRoute = async () => {
   const [news, thoughts, tools, prompts] = await Promise.all([
@@ -61,19 +62,25 @@ export const GET: APIRoute = async () => {
     });
   }
 
-  // Load radar data
-  const radarFiles = import.meta.glob('../data/radar/????-??-??.json', { eager: true });
-  for (const [path, mod] of Object.entries(radarFiles)) {
-    const data = (mod as any).default;
-    const items = [...(data.featured || []), ...(data.picks || [])];
+  // Load radar data, bounded to the visible window. Older day-files stay on
+  // disk for the horizon bot but have no public /radar/<date> route, so indexing
+  // them would point search results at pages that 404. Lazy glob keeps the build
+  // from reading the entire archive into memory.
+  const radarFiles = import.meta.glob('../data/radar/????-??-??.json');
+  const visibleDates = radarManifest.dates.slice(0, RADAR_VISIBLE_DAYS);
+  for (const date of visibleDates) {
+    const key = Object.keys(radarFiles).find((k) => k.includes(date));
+    if (!key) continue;
+    const data = (await radarFiles[key]()) as any;
+    const items = [...(data.default.featured || []), ...(data.default.picks || [])];
     for (const item of items) {
       entries.push({
         title: item.name,
         summary: item.tagline || item.why_radar || '',
-        url: `/radar/${data.date}`,
+        url: `/radar/${data.default.date}`,
         type: 'radar',
         tags: item.category ? [item.category] : [],
-        date: data.date,
+        date: data.default.date,
       });
     }
   }


### PR DESCRIPTION
Replaces #143 (conflicted after 19 days). Code-only rebuild onto current main; the original's stale bot data files are dropped (they regenerate).

**radar_bot push hardening** directly fixes the failure mode behind today's broken-ref incident — replaces `stash → pull --rebase → stash pop` with **commit-first + `pull --rebase --autostash` + bounded retry + `rebase --abort`**. Plus orphan day-file pruning to cap the archive footprint.

Build verified locally (806 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)