### PR TITLE
chore(bot): serialize + health-gate all bot git operations

### DIFF
--- a/bot/ai_news_digest.py
+++ b/bot/ai_news_digest.py
@@ -20,6 +20,7 @@ from dotenv import load_dotenv
 from anthropic import Anthropic
 
 from pipeline_log import log_run
+import git_safe
 
 # Paths
 BOT_DIR = Path(__file__).parent
@@ -175,13 +176,12 @@ def save_and_push(content: str, entries: list[dict], history: dict):
     })
     save_history(history)
 
-    # Commit and push
-    os.chdir(REPO_DIR)
-    subprocess.run(["git", "add", f"src/content/news-and-updates/{filename}", "bot/digest_history.json", "src/data/pipeline/runs.json"], check=True)
+    # Commit and push (serialized + health-checked via git_safe)
     msg = f"bot: add AI news digest ({slug_date})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    subprocess.run(["git", "push"], check=True)
-    print(f"Pushed: {msg}")
+    git_safe.safe_commit_and_push(
+        [f"src/content/news-and-updates/{filename}", "bot/digest_history.json", "src/data/pipeline/runs.json"],
+        msg,
+    )
 
 
 def ping_healthcheck(status="success"):

--- a/bot/ai_thoughts_bot.py
+++ b/bot/ai_thoughts_bot.py
@@ -22,6 +22,7 @@ from dotenv import load_dotenv
 from anthropic import Anthropic
 
 from pipeline_log import log_run
+import git_safe
 
 # Paths
 BOT_DIR = Path(__file__).parent
@@ -191,16 +192,13 @@ def save_and_push(content: str, history: dict, *, push: bool = True):
     })
     save_history(history)
 
-    # Commit and push
-    os.chdir(REPO_DIR)
-    subprocess.run(["git", "add", f"src/content/thoughts/{filename}", "bot/thoughts_history.json", "src/data/pipeline/runs.json"], check=True)
+    # Commit and push (serialized + health-checked via git_safe)
     msg = f"bot: add thought ({slug_date})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    if push:
-        subprocess.run(["git", "push"], check=True)
-        print(f"Pushed: {msg}")
-    else:
-        print(f"Committed (no push): {msg}")
+    git_safe.safe_commit_and_push(
+        [f"src/content/thoughts/{filename}", "bot/thoughts_history.json", "src/data/pipeline/runs.json"],
+        msg,
+        push=push,
+    )
 
 
 def ping_healthcheck(status="success"):

--- a/bot/git_safe.py
+++ b/bot/git_safe.py
@@ -1,0 +1,242 @@
+"""Shared safe-git plumbing for SOFT CAT bots.
+
+Every bot mutates the SAME working tree (this repo) on overlapping systemd
+timers, and `scripts/auto-build.sh` checks out feature branches in it too.
+Nothing coordinated those git operations: two concurrent ref/index writes — or
+a single write interrupted midway (dropped SSH session, killed process, power
+loss) — can leave the repository corrupt. This module exists because exactly
+that happened: an interrupted ref write left `.git/HEAD` and two branch refs as
+zero-byte files, which made the whole tree look like a fresh repo and silently
+broke every bot that ran afterwards.
+
+`safe_commit_and_push()` is the single entry point bots should use to land a
+commit on `main`. It:
+
+  1. Takes a process-wide exclusive ``flock`` (``/tmp/softcat-git.lock``) so no
+     two git-mutating runs — bot vs bot, bot vs auto-build — ever overlap.
+  2. Verifies repo health (HEAD resolves, no zero-byte refs) BEFORE touching
+     anything, and raises :class:`RepoCorruptError` instead of piling commits on
+     top of a broken repo. A bot that catches this should ping its failure URL
+     and exit, so a human is alerted while the damage is still small.
+  3. Runs ``stash -> pull --rebase -> stash pop -> add -> commit -> push``, with
+     the push retried after a fresh rebase on a non-fast-forward.
+
+For branch-based work (e.g. opening a proposal PR) use :func:`git_lock` directly
+to wrap the git operations under the same lock.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+# bot/ -> repo root
+REPO_DIR = Path(__file__).resolve().parent.parent
+LOCK_PATH = "/tmp/softcat-git.lock"
+LOCK_TIMEOUT = 300  # seconds a bot will wait for the lock before giving up
+PUSH_RETRIES = 3
+
+
+class RepoCorruptError(RuntimeError):
+    """The working tree's git metadata is in an unusable state.
+
+    Raised before any mutation, so callers can alert and abort without making
+    the corruption worse.
+    """
+
+
+class GitLockTimeout(RuntimeError):
+    """Could not acquire the shared git lock within the timeout."""
+
+
+class WrongBranchError(RuntimeError):
+    """The working tree is not on the branch the bot expected to commit to."""
+
+
+def _git(args, *, check=True, capture=True):
+    """Run a git command in REPO_DIR."""
+    return subprocess.run(
+        ["git", "-C", str(REPO_DIR), *args],
+        check=check,
+        capture_output=capture,
+        text=True,
+    )
+
+
+@contextmanager
+def git_lock(timeout: int = LOCK_TIMEOUT):
+    """Hold an exclusive, process-wide lock on the shared working tree.
+
+    Serializes every git-mutating sequence across all bots and auto-build so
+    their ref/index writes can never interleave. Blocks (polling) up to
+    ``timeout`` seconds, then raises :class:`GitLockTimeout` rather than risk a
+    concurrent run.
+    """
+    fd = open(LOCK_PATH, "w")
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EAGAIN, errno.EACCES):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise GitLockTimeout(
+                        f"git lock held by another process for >{timeout}s"
+                    ) from exc
+                time.sleep(1.0)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            fd.close()
+
+
+def _zero_byte_refs() -> list[str]:
+    """Return any loose ref files that are empty — the classic interrupted-write
+    corruption signature."""
+    heads = REPO_DIR / ".git" / "refs" / "heads"
+    bad = []
+    if heads.is_dir():
+        for ref in heads.rglob("*"):
+            if ref.is_file() and ref.stat().st_size == 0:
+                bad.append(str(ref.relative_to(REPO_DIR / ".git")))
+    return bad
+
+
+def check_repo_health() -> None:
+    """Raise :class:`RepoCorruptError` if the repo is in the broken state this
+    module guards against.
+
+    Cheap and targeted (no full ``fsck``): confirms HEAD resolves to a real
+    commit and that no loose ref file is zero bytes. Catches the exact failure
+    that motivated this module.
+    """
+    if not (REPO_DIR / ".git").exists():
+        raise RepoCorruptError(f"{REPO_DIR} is not a git repository")
+
+    empty = _zero_byte_refs()
+    if empty:
+        raise RepoCorruptError(
+            "zero-byte (corrupt) ref file(s): " + ", ".join(empty)
+        )
+
+    head = _git(["rev-parse", "--verify", "-q", "HEAD"], check=False)
+    if head.returncode != 0 or not head.stdout.strip():
+        raise RepoCorruptError(
+            "HEAD does not resolve to a valid commit "
+            f"(git rev-parse exited {head.returncode})"
+        )
+
+
+def current_branch() -> str:
+    """Return the checked-out branch name (empty string if detached)."""
+    res = _git(["symbolic-ref", "--quiet", "--short", "HEAD"], check=False)
+    return res.stdout.strip()
+
+
+def _stash_push() -> bool:
+    """Stash stray changes (incl. untracked) so pull --rebase can't fail on a
+    dirty tree. Returns True if something was stashed."""
+    res = _git(["stash", "--include-untracked"])
+    return "No local changes" not in res.stdout
+
+
+def safe_commit_and_push(
+    paths: list[str],
+    message: str,
+    *,
+    push: bool = True,
+    retries: int = PUSH_RETRIES,
+    expected_branch: str = "main",
+) -> bool:
+    """Land ``paths`` on ``expected_branch`` as one commit, safely.
+
+    Serialized under the shared lock and gated on a health check. Returns True
+    if a commit was created, False if there was nothing to commit. Raises
+    :class:`RepoCorruptError` if the repo is broken before we start.
+
+    If ``expected_branch`` is set (the default ``"main"``) and the working tree
+    is on a different branch, raises :class:`WrongBranchError` rather than
+    committing content to the wrong place. This guards against landing on a
+    transient build/proposal branch that auto-build or horizon left checked out
+    (the very situation this incident left HEAD in). Pass ``expected_branch=""``
+    to skip the check.
+
+    ``paths`` are repo-relative; they are staged explicitly (never ``git add
+    .``). The push is retried after a fresh rebase on non-fast-forward.
+    """
+    with git_lock():
+        check_repo_health()
+
+        if expected_branch:
+            on = current_branch()
+            if on != expected_branch:
+                raise WrongBranchError(
+                    f"refusing to commit: on '{on or '(detached)'}', "
+                    f"expected '{expected_branch}'"
+                )
+
+        stashed = _stash_push()
+        try:
+            _git(["pull", "--rebase"])
+        except subprocess.CalledProcessError:
+            # Leave the repo in a clean state rather than mid-rebase.
+            _git(["rebase", "--abort"], check=False)
+            raise
+        finally:
+            if stashed:
+                _git(["stash", "pop"])
+
+        _git(["add", "--", *paths])
+
+        if _git(["diff", "--cached", "--quiet"], check=False).returncode == 0:
+            print("[git_safe] Nothing staged to commit.")
+            return False
+
+        _git(["commit", "-m", message])
+
+        if not push:
+            print(f"[git_safe] Committed (no push): {message.splitlines()[0]}")
+            return True
+
+        last_err = None
+        for attempt in range(1, retries + 1):
+            res = _git(["push"], check=False)
+            if res.returncode == 0:
+                print(f"[git_safe] Pushed: {message.splitlines()[0]}")
+                return True
+            last_err = res.stderr.strip()
+            print(
+                f"[git_safe] push attempt {attempt}/{retries} failed "
+                f"({last_err}); rebasing and retrying"
+            )
+            _git(["pull", "--rebase"], check=False)
+
+        raise RuntimeError(f"git push failed after {retries} attempts: {last_err}")
+
+
+def main(argv: list[str]) -> int:
+    """CLI health check — used by auto-build.sh and ad-hoc pre-flight.
+
+    ``python3 bot/git_safe.py --check`` exits 0 if healthy, 1 if corrupt.
+    """
+    try:
+        check_repo_health()
+    except RepoCorruptError as exc:
+        print(f"REPO CORRUPT: {exc}", file=sys.stderr)
+        return 1
+    print(f"repo healthy: {REPO_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/bot/git_safe.py
+++ b/bot/git_safe.py
@@ -112,13 +112,60 @@ def _zero_byte_refs() -> list[str]:
     return bad
 
 
+def _local_ref_targets() -> dict:
+    """Map every local branch ref -> the raw SHA (or ``ref:`` target) it records.
+
+    Read straight from the filesystem (loose refs + packed-refs) rather than via
+    ``git for-each-ref``, because git's own ref enumeration can choke once a ref
+    is already broken — exactly when we most need to inspect it.
+    """
+    git_dir = REPO_DIR / ".git"
+    targets: dict[str, str] = {}
+    heads = git_dir / "refs" / "heads"
+    if heads.is_dir():
+        for ref in heads.rglob("*"):
+            if ref.is_file():
+                name = "refs/heads/" + str(ref.relative_to(heads)).replace("\\", "/")
+                targets[name] = ref.read_text(errors="replace").strip()
+    packed = git_dir / "packed-refs"
+    if packed.is_file():
+        for line in packed.read_text(errors="replace").splitlines():
+            line = line.strip()
+            if not line or line[0] in "#^":
+                continue
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+                targets.setdefault(parts[1], parts[0])
+    return targets
+
+
+def _bad_object_refs() -> list[str]:
+    """Local branch refs whose recorded SHA does not resolve to an existing
+    object.
+
+    This is the corruption that silently broke radar_bot for a month: a stray
+    ``refs/heads/add/horizon-ci-validator`` pointed at a missing object, so every
+    ``git pull --rebase`` died with ``fatal: bad object refs/heads/...`` and no
+    content could be pushed. A zero-byte scan misses it (the ref file has a
+    plausible 40-char SHA), so check it explicitly.
+    """
+    bad = []
+    for name, target in _local_ref_targets().items():
+        if not target or target.startswith("ref:"):
+            continue  # empty -> covered by zero-byte scan; symref -> not an object
+        if _git(["cat-file", "-e", target], check=False).returncode != 0:
+            bad.append(name)
+    return bad
+
+
 def check_repo_health() -> None:
-    """Raise :class:`RepoCorruptError` if the repo is in the broken state this
+    """Raise :class:`RepoCorruptError` if the repo is in a broken state this
     module guards against.
 
-    Cheap and targeted (no full ``fsck``): confirms HEAD resolves to a real
-    commit and that no loose ref file is zero bytes. Catches the exact failure
-    that motivated this module.
+    Cheap and targeted (no full ``fsck``): confirms HEAD resolves, no loose ref
+    file is zero bytes, and no local branch ref points at a missing object.
+    Catches both the interrupted-write signature that motivated this module and
+    the bad-object ref that stalled radar_bot for a month.
     """
     if not (REPO_DIR / ".git").exists():
         raise RepoCorruptError(f"{REPO_DIR} is not a git repository")
@@ -134,6 +181,12 @@ def check_repo_health() -> None:
         raise RepoCorruptError(
             "HEAD does not resolve to a valid commit "
             f"(git rev-parse exited {head.returncode})"
+        )
+
+    broken = _bad_object_refs()
+    if broken:
+        raise RepoCorruptError(
+            "branch ref(s) pointing at a missing object: " + ", ".join(broken)
         )
 
 

--- a/bot/horizon_bot.py
+++ b/bot/horizon_bot.py
@@ -44,6 +44,7 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 
 from pipeline_log import log_run as _log_run
+import git_safe
 
 # Paths
 BOT_DIR = Path(__file__).parent
@@ -740,30 +741,13 @@ def commit_shifts(shifts_changed: bool):
     """
     if not shifts_changed:
         return
-    os.chdir(REPO_DIR)
-    stash = subprocess.run(["git", "stash", "--include-untracked"],
-                           capture_output=True, text=True)
-    stashed = "No local changes" not in stash.stdout
-    subprocess.run(["git", "pull", "--rebase"], check=True)
-    if stashed:
-        subprocess.run(["git", "stash", "pop"], check=True)
-
-    subprocess.run([
-        "git", "add",
-        "src/data/horizon/shifts.json",
-        "src/data/pipeline/runs.json",
-    ], check=True)
-
-    result = subprocess.run(["git", "diff", "--cached", "--quiet"])
-    if result.returncode == 0:
-        print("[horizon_bot] Nothing staged after shift update.")
-        return
-
+    # Serialized + health-checked + rebased-before-push via git_safe.
     today = date.today().isoformat()
     msg = f"bot: refresh horizon shifts ({today})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    subprocess.run(["git", "push"], check=True)
-    print(f"[horizon_bot] Pushed: {msg}")
+    git_safe.safe_commit_and_push(
+        ["src/data/horizon/shifts.json", "src/data/pipeline/runs.json"],
+        msg,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -817,78 +801,84 @@ def create_proposal_pr(now_proposals: list[dict]) -> str | None:
     except (subprocess.CalledProcessError, json.JSONDecodeError):
         pass
 
-    # Make sure we're starting from latest main
-    subprocess.run(["git", "fetch", "origin", "main"], check=True,
-                   capture_output=True)
+    # All branch/ref mutations below run under the shared git lock so they
+    # cannot interleave with another bot committing to main (this path switches
+    # the working tree's branch via `checkout -B`). Health-checked first.
+    with git_safe.git_lock():
+        git_safe.check_repo_health()
 
-    # Create or reset the branch from origin/main
-    subprocess.run(["git", "checkout", "-B", branch, "origin/main"],
-                   check=True, capture_output=True)
+        # Make sure we're starting from latest main
+        subprocess.run(["git", "fetch", "origin", "main"], check=True,
+                       capture_output=True)
 
-    # Load current now.json and append proposals
-    now_file = HORIZON_DIR / "now.json"
-    current = _read_json(now_file, [])
-    existing_ids = {e.get("id") for e in current}
+        # Create or reset the branch from origin/main
+        subprocess.run(["git", "checkout", "-B", branch, "origin/main"],
+                       check=True, capture_output=True)
 
-    new_entries = []
-    for p in now_proposals:
-        if p["id"] not in existing_ids:
-            new_entries.append(_proposal_to_entry(p))
+        # Load current now.json and append proposals
+        now_file = HORIZON_DIR / "now.json"
+        current = _read_json(now_file, [])
+        existing_ids = {e.get("id") for e in current}
 
-    if not new_entries:
-        # All proposals already exist, nothing to do
-        subprocess.run(["git", "checkout", "main"], capture_output=True)
-        return None
+        new_entries = []
+        for p in now_proposals:
+            if p["id"] not in existing_ids:
+                new_entries.append(_proposal_to_entry(p))
 
-    current.extend(new_entries)
-    now_file.write_text(json.dumps(current, indent=2) + "\n")
+        if not new_entries:
+            # All proposals already exist, nothing to do
+            subprocess.run(["git", "checkout", "main"], capture_output=True)
+            return None
 
-    # Commit and push
-    subprocess.run(["git", "add", str(now_file)], check=True)
-    titles = ", ".join(e["title"][:50] for e in new_entries)
-    msg = f"bot(horizon): propose {len(new_entries)} Now entries\n\n{titles}"
-    subprocess.run(["git", "commit", "-m", msg], check=True,
-                   capture_output=True)
-    subprocess.run(["git", "push", "-u", "origin", branch, "--force"],
-                   check=True, capture_output=True)
+        current.extend(new_entries)
+        now_file.write_text(json.dumps(current, indent=2) + "\n")
 
-    pr_url = None
-    if existing_pr:
-        # PR already exists, force-push updated the branch
-        pr_url = existing_pr["url"]
-        print(f"[horizon_bot] Updated existing PR: {pr_url}")
-    else:
-        # Create new PR
-        body_lines = ["## Horizon bot proposals\n"]
-        for e in new_entries:
-            themes = ", ".join(e["themes"])
-            evidence_count = len(e.get("evidence", []))
+        # Commit and push
+        subprocess.run(["git", "add", str(now_file)], check=True)
+        titles = ", ".join(e["title"][:50] for e in new_entries)
+        msg = f"bot(horizon): propose {len(new_entries)} Now entries\n\n{titles}"
+        subprocess.run(["git", "commit", "-m", msg], check=True,
+                       capture_output=True)
+        subprocess.run(["git", "push", "-u", "origin", branch, "--force"],
+                       check=True, capture_output=True)
+
+        pr_url = None
+        if existing_pr:
+            # PR already exists, force-push updated the branch
+            pr_url = existing_pr["url"]
+            print(f"[horizon_bot] Updated existing PR: {pr_url}")
+        else:
+            # Create new PR
+            body_lines = ["## Horizon bot proposals\n"]
+            for e in new_entries:
+                themes = ", ".join(e["themes"])
+                evidence_count = len(e.get("evidence", []))
+                body_lines.append(
+                    f"- **{e['title']}** ({e['confidence']}, {themes}) "
+                    f"— {evidence_count} sources"
+                )
             body_lines.append(
-                f"- **{e['title']}** ({e['confidence']}, {themes}) "
-                f"— {evidence_count} sources"
+                "\n---\nGenerated by `horizon_bot.py`. Review, edit, then merge."
             )
-        body_lines.append(
-            "\n---\nGenerated by `horizon_bot.py`. Review, edit, then merge."
-        )
-        body = "\n".join(body_lines)
+            body = "\n".join(body_lines)
 
-        try:
-            result = subprocess.run(
-                ["gh", "pr", "create",
-                 "--title", f"Horizon: {len(new_entries)} Now proposals ({today})",
-                 "--body", body,
-                 "--base", "main",
-                 "--head", branch],
-                capture_output=True, text=True, check=True,
-            )
-            pr_url = result.stdout.strip()
-            print(f"[horizon_bot] Created PR: {pr_url}")
-        except subprocess.CalledProcessError as e:
-            print(f"[horizon_bot] gh pr create failed: {e.stderr}")
+            try:
+                result = subprocess.run(
+                    ["gh", "pr", "create",
+                     "--title", f"Horizon: {len(new_entries)} Now proposals ({today})",
+                     "--body", body,
+                     "--base", "main",
+                     "--head", branch],
+                    capture_output=True, text=True, check=True,
+                )
+                pr_url = result.stdout.strip()
+                print(f"[horizon_bot] Created PR: {pr_url}")
+            except subprocess.CalledProcessError as e:
+                print(f"[horizon_bot] gh pr create failed: {e.stderr}")
 
-    # Return to main
-    subprocess.run(["git", "checkout", "main"], capture_output=True)
-    return pr_url
+        # Return to main
+        subprocess.run(["git", "checkout", "main"], capture_output=True)
+        return pr_url
 
 
 # --------------------------------------------------------------------------- #

--- a/bot/model_data_bot.py
+++ b/bot/model_data_bot.py
@@ -35,6 +35,7 @@ import httpx
 from dotenv import load_dotenv
 
 from pipeline_log import log_run
+import git_safe
 
 BOT_DIR = Path(__file__).parent
 load_dotenv(BOT_DIR / ".env")
@@ -282,30 +283,14 @@ def post_suspects_to_discord(suspects):
 
 
 def git_commit_and_push():
-    os.chdir(REPO_DIR)
-    # Stash any stray uncommitted files (from other bots mid-run, etc.) so
-    # pull --rebase cannot fail on dirty worktree, then restore them after.
-    stash_result = subprocess.run(
-        ["git", "stash", "--include-untracked", "--keep-index"],
-        capture_output=True, text=True,
-    )
-    stashed = "No local changes" not in stash_result.stdout
-    subprocess.run(["git", "pull", "--rebase"], check=True)
-    if stashed:
-        subprocess.run(["git", "stash", "pop"], check=True)
-    subprocess.run(["git", "add", "src/data/models.json", "src/data/pipeline/runs.json"], check=True)
-
-    # Check if there are actually staged changes after pull
-    result = subprocess.run(["git", "diff", "--cached", "--quiet"])
-    if result.returncode == 0:
-        print("No staged changes after pull. Exiting.")
-        return
-
+    # Serialized under the shared git lock, health-checked, and rebased before
+    # push by git_safe (which also stashes any stray files from other bots).
     today = date.today().isoformat()
     msg = f"bot: update model data ({today})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    subprocess.run(["git", "push"], check=True)
-    print(f"Pushed: {msg}")
+    git_safe.safe_commit_and_push(
+        ["src/data/models.json", "src/data/pipeline/runs.json"],
+        msg,
+    )
 
 
 def ping_healthcheck(status="success"):

--- a/bot/prompt_library_bot.py
+++ b/bot/prompt_library_bot.py
@@ -22,6 +22,7 @@ from dotenv import load_dotenv
 from anthropic import Anthropic
 
 from pipeline_log import log_run
+import git_safe
 
 # Paths
 BOT_DIR = Path(__file__).parent
@@ -252,17 +253,10 @@ def save_and_push(prompts: list[str], history: dict, *, push: bool = True):
 
     save_history(history)
 
-    # Commit and push
-    os.chdir(REPO_DIR)
+    # Commit and push (serialized + health-checked via git_safe)
     git_add = files_created + ["bot/prompt_history.json", "src/data/pipeline/runs.json"]
-    subprocess.run(["git", "add"] + git_add, check=True)
     msg = f"bot: add {len(prompts)} prompt(s) to library"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    if push:
-        subprocess.run(["git", "push"], check=True)
-        print(f"Pushed: {msg}")
-    else:
-        print(f"Committed (no push): {msg}")
+    git_safe.safe_commit_and_push(git_add, msg, push=push)
 
 
 def ping_healthcheck(status="success"):

--- a/bot/radar_bot.py
+++ b/bot/radar_bot.py
@@ -20,6 +20,7 @@ from dotenv import load_dotenv
 from anthropic import Anthropic
 
 from pipeline_log import log_run as _log_run
+import git_safe
 
 # Paths
 BOT_DIR = Path(__file__).parent
@@ -378,45 +379,53 @@ def save_and_push(radar_data: dict, history: dict):
     })
     save_history(history)
 
-    # Stage our files (prune_orphan_files already staged any deletions)
-    _git([
-        "add",
-        f"src/data/radar/{filename}",
-        "src/data/radar/index.json",
-        "bot/radar_history.json",
-        "src/data/pipeline/runs.json",
-    ])
+    # All git mutations run under the shared lock so they can't interleave with
+    # another bot's ref writes, and behind a health check so a corrupt repo is
+    # caught loudly (the day's data files are already on disk and recover next
+    # run). The commit-before-sync + bounded-retry design below is preserved.
+    with git_safe.git_lock():
+        git_safe.check_repo_health()
 
-    # Only commit if there are staged changes
-    if _git(["diff", "--cached", "--quiet"]).returncode == 0:
-        print("No changes to commit.")
-        return
+        # Stage our files (prune_orphan_files already staged any deletions)
+        _git([
+            "add",
+            f"src/data/radar/{filename}",
+            "src/data/radar/index.json",
+            "bot/radar_history.json",
+            "src/data/pipeline/runs.json",
+        ])
 
-    msg = f"bot: add radar data ({today})"
-    _git(["commit", "-m", msg], check=True)
-    print(f"Committed: {msg}")
-
-    # Sync with remote and push, retrying if a concurrent bot pushed first.
-    # --autostash handles any stray dirty files (e.g. runs.json) without the old
-    # stash-pop crash. A bounded retry covers the push race between staggered bots.
-    for attempt in range(1, 4):
-        rebase = _git(["pull", "--rebase", "--autostash"])
-        if rebase.returncode != 0:
-            print(f"[radar_bot] rebase failed (attempt {attempt}):\n{rebase.stderr.strip()}")
-            _git(["rebase", "--abort"])
-            time.sleep(3)
-            continue
-        push = _git(["push"])
-        if push.returncode == 0:
-            print(f"Pushed: {msg}")
+        # Only commit if there are staged changes
+        if _git(["diff", "--cached", "--quiet"]).returncode == 0:
+            print("No changes to commit.")
             return
-        print(f"[radar_bot] push rejected (attempt {attempt}):\n{push.stderr.strip()}")
-        time.sleep(3)
 
-    raise RuntimeError(
-        "radar_bot: could not push after 3 attempts. Today's radar data is "
-        "committed locally and will be pushed on the next successful run."
-    )
+        msg = f"bot: add radar data ({today})"
+        _git(["commit", "-m", msg], check=True)
+        print(f"Committed: {msg}")
+
+        # Sync with remote and push, retrying if a concurrent bot pushed first.
+        # --autostash handles any stray dirty files (e.g. runs.json) without the
+        # old stash-pop crash. A bounded retry covers the push race between
+        # staggered bots.
+        for attempt in range(1, 4):
+            rebase = _git(["pull", "--rebase", "--autostash"])
+            if rebase.returncode != 0:
+                print(f"[radar_bot] rebase failed (attempt {attempt}):\n{rebase.stderr.strip()}")
+                _git(["rebase", "--abort"])
+                time.sleep(3)
+                continue
+            push = _git(["push"])
+            if push.returncode == 0:
+                print(f"Pushed: {msg}")
+                return
+            print(f"[radar_bot] push rejected (attempt {attempt}):\n{push.stderr.strip()}")
+            time.sleep(3)
+
+        raise RuntimeError(
+            "radar_bot: could not push after 3 attempts. Today's radar data is "
+            "committed locally and will be pushed on the next successful run."
+        )
 
 
 def post_to_discord(radar_data: dict):

--- a/bot/tool_of_the_week.py
+++ b/bot/tool_of_the_week.py
@@ -21,6 +21,7 @@ from dotenv import load_dotenv
 from anthropic import Anthropic
 
 from pipeline_log import log_run
+import git_safe
 
 # Paths
 BOT_DIR = Path(__file__).parent
@@ -180,16 +181,12 @@ Rules:
 
 
 def git_commit_and_push(filename: str):
-    """Commit the new file and push."""
-    os.chdir(REPO_DIR)
-
-    subprocess.run(["git", "add", f"src/content/tools/{filename}", "bot/history.json", "src/data/pipeline/runs.json"], check=True)
-
+    """Commit the new file and push (serialized + health-checked via git_safe)."""
     msg = f"bot: add tool of the week ({filename.replace('.md', '')})"
-    subprocess.run(["git", "commit", "-m", msg], check=True)
-    subprocess.run(["git", "push"], check=True)
-
-    print(f"Pushed: {msg}")
+    git_safe.safe_commit_and_push(
+        [f"src/content/tools/{filename}", "bot/history.json", "src/data/pipeline/runs.json"],
+        msg,
+    )
 
 
 def ping_healthcheck(status="success"):

--- a/scripts/auto-build.sh
+++ b/scripts/auto-build.sh
@@ -28,6 +28,29 @@ trap 'rm -f "$LOCK_FILE"; cd "$REPO_DIR" && git checkout main 2>/dev/null || tru
 
 cd "$REPO_DIR"
 
+# Pre-flight: never build on top of a corrupt repo (interrupted-write damage,
+# zero-byte refs, unresolvable HEAD). Abort loudly so a human repairs it instead
+# of the build piling commits onto a broken tree.
+if ! python3 bot/git_safe.py --check >> "$LOG_FILE" 2>&1; then
+    echo "[$(date)] Repo health check FAILED — aborting build, manual repair needed." >> "$LOG_FILE"
+    if [ -n "${SOFTCAT_ALERT_WEBHOOK:-}" ]; then
+        curl -s -X POST "$SOFTCAT_ALERT_WEBHOOK" -H 'Content-Type: application/json' \
+            -d '{"content":"⚠️ softcat auto-build aborted: git repo health check failed (corrupt state). Manual repair needed."}' >/dev/null 2>&1 || true
+    fi
+    exit 1
+fi
+
+# Serialize ALL git-mutating work against the content bots via the shared lock
+# (bot/git_safe.py uses the same file). Held for the whole run so a bot can never
+# commit to main while we are on a feature branch or mid-checkout. A bot that
+# overlaps simply waits, then recovers on its next scheduled run. The fd stays
+# open for the script's lifetime, releasing the lock automatically on exit.
+exec 200>"/tmp/softcat-git.lock"
+if ! flock -w 600 200; then
+    echo "[$(date)] Could not acquire shared git lock within 600s; a bot is busy. Skipping this run." >> "$LOG_FILE"
+    exit 0
+fi
+
 # Start clean on main
 git checkout main 2>/dev/null
 git pull --ff-only origin main 2>/dev/null || true


### PR DESCRIPTION
## Why
The six content bots share one working tree on overlapping systemd timers, and `auto-build.sh` checks out feature branches in it too — with **no coordination**. An interrupted git write (a dropped session) recently left `.git/HEAD` and two branch refs as zero-byte files, silently breaking every bot that ran afterwards. Nothing detected the corruption; bots just kept piling on top of it.

## What
New shared module **`bot/git_safe.py`**:
- **`git_lock()`** — process-wide `flock` (`/tmp/softcat-git.lock`) so no two git-mutating runs (bot↔bot, bot↔auto-build) ever interleave.
- **`check_repo_health()`** — cheap pre-flight that raises on the exact corruption signature (zero-byte refs, unresolvable HEAD) instead of mutating a broken repo.
- **`safe_commit_and_push()`** — `stash → pull --rebase → add → commit → push` (push retried after a fresh rebase), all under the lock. **Refuses to commit unless on `main`** — so a bot can never land content on a transient build/proposal branch (this incident left HEAD on `auto/80…`).

### Adoption
- All six content bots migrated to `safe_commit_and_push`.
- `horizon.create_proposal_pr` and `radar_bot` keep their bespoke branch/retry logic but now run **inside `git_lock()` with a health gate**. radar's freshly-added commit-before-sync recovery design is preserved untouched.
- `auto-build.sh`: aborts (with optional `$SOFTCAT_ALERT_WEBHOOK` alert) if the health check fails, and holds the shared lock for its whole run so its branch switches can't race a bot commit.

## Testing
Sandbox repo exercised: health pass/fail, zero-byte-ref + bad-HEAD detection, lock mutual exclusion (threads), branch guard (refuses on feature branch), and full commit→push→remote. All bots `py_compile` clean and import via the bot venv.

## Notes
- No behavioural change to *what* the bots publish — only *how* they touch git.
- Optional: set `SOFTCAT_ALERT_WEBHOOK` in auto-build's environment to get a Discord ping if the repo is ever found corrupt again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)