### PR TITLE
style(design): polish pass — fix pinned-badge heading semantics

### DIFF
--- a/src/components/FeaturedPost.astro
+++ b/src/components/FeaturedPost.astro
@@ -19,10 +19,10 @@ const { entries } = Astro.props;
 
 {entries.length > 0 && (
   <section class="max-w-5xl mx-auto px-6 py-10">
-    <h2 class="font-mono text-xs text-text-muted mb-4 flex items-center gap-2">
+    <div class="font-mono text-xs text-text-muted mb-4 flex items-center gap-2">
       <span class="text-neon-cyan">&#9733;</span>
       <span>pinned</span>
-    </h2>
+    </div>
 
     <div class="grid gap-5">
       {entries.map((entry, index) => (


### PR DESCRIPTION
## Live visual audit → fix
Ran a `/design-review` style audit against the live site (homepage, /radar, /horizon, desktop + mobile). **The site is in good shape** — strong distinctive hero (terminal motif), on-brand neon-on-void palette, JetBrains Mono + Inter, the PAST|NOW|NEXT horizon timeline, no console errors, excellent perf (TTFB ~44ms). Not AI slop.

## Fixed
**Pinned badge was an `<h2>`.** The "★ pinned" label on the homepage featured thought was marked up as `<h2>` purely for styling (`text-xs text-muted`) — injecting a 12px/400 "pinned" entry into the document outline between the H1 and the real content H3s. It's a decorative status badge, not a section heading.

- `<h2>` → `<div>`, identical classes, **zero visual change** (verified before/after).
- Clean heading hierarchy now (H1 → section H2s → content H3s) for screen readers and SEO.
- Build passes (806 pages).

Checked the rest of the codebase for the same anti-pattern: the uppercase eyebrow `<h2>`s on /pipeline, /radar, /tags ("Bot roster", "Today's picks", etc.) are **legitimate section headings** and were correctly left alone.

## Observations (not changed — your call)
- **Radar data is stale:** latest is `2026-05-10`, ~1 month old. Operational (`radar_bot` not producing), not design.
- Minor polish candidates deferred as subjective layout calls: dead-space band atop /radar, the small trace-tape receipt floating in a large panel on the homepage, and the mobile hero terminal prompt wrapping awkwardly (`_` cursor floats). Happy to take any of these on with direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)