### PR TITLE
feat: opt-in Cloudflare Web Analytics (single source of truth)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,17 @@
+// Cloudflare Web Analytics — cookieless, privacy-friendly visitor stats.
+//
+// To turn analytics ON:
+//   1. Cloudflare dashboard -> Web Analytics -> "Add a site" -> softcat.ai
+//   2. Copy the site token (a ~32-char hex string; it is public by design).
+//   3. Paste it into CF_BEACON_TOKEN_OVERRIDE below (or set PUBLIC_CF_BEACON_TOKEN
+//      in the build environment), then commit + deploy.
+//
+// While the token is empty, NOTHING is rendered: no beacon script ships, and the
+// /privacy page truthfully says "no analytics". The two stay in sync automatically.
+const CF_BEACON_TOKEN_OVERRIDE = '';
+
+export const CF_BEACON_TOKEN: string =
+  import.meta.env.PUBLIC_CF_BEACON_TOKEN || CF_BEACON_TOKEN_OVERRIDE;
+
+/** True when Cloudflare Web Analytics is configured and the beacon should load. */
+export const ANALYTICS_ENABLED: boolean = CF_BEACON_TOKEN.length > 0;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import SearchOverlay from '../components/SearchOverlay.tsx';
+import { CF_BEACON_TOKEN, ANALYTICS_ENABLED } from '../consts';
 import '../styles/global.css';
 
 interface Props {
@@ -77,6 +78,13 @@ const breadcrumbSchema = breadcrumbs && breadcrumbs.length > 0 ? {
       <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
     )}
     <slot name="head" />
+    {ANALYTICS_ENABLED && (
+      <script
+        defer
+        src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon={JSON.stringify({ token: CF_BEACON_TOKEN })}
+      ></script>
+    )}
   </head>
   <body class="flex flex-col min-h-screen">
     <Header />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { ANALYTICS_ENABLED } from '../consts';
 ---
 
 <BaseLayout title="Privacy" description="How SOFT CAT .ai handles your data.">
@@ -17,10 +18,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div>
         <h2 class="font-mono text-sm font-bold text-neon-amber mb-3">What we collect</h2>
         <ul class="space-y-2 font-mono text-sm">
-          <li class="flex items-start gap-2">
-            <span class="text-neon-amber mt-0.5">&#9656;</span>
-            <span>Nothing. No cookies, no trackers, no analytics.</span>
-          </li>
+          {ANALYTICS_ENABLED ? (
+            <li class="flex items-start gap-2">
+              <span class="text-neon-amber mt-0.5">&#9656;</span>
+              <span>No cookies, no cross-site tracking, no personal data. We use Cloudflare Web Analytics for aggregate page views only. It sets no cookies and does not fingerprint or follow you across sites.</span>
+            </li>
+          ) : (
+            <li class="flex items-start gap-2">
+              <span class="text-neon-amber mt-0.5">&#9656;</span>
+              <span>Nothing. No cookies, no trackers, no analytics.</span>
+            </li>
+          )}
         </ul>
       </div>
 
@@ -31,6 +39,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <span class="text-neon-cyan mt-0.5">&#9656;</span>
             <span><strong class="text-text-bright">GitHub Pages</strong> hosts this site. GitHub may collect basic server logs. See their <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" class="text-neon-cyan hover:underline" target="_blank" rel="noopener noreferrer">privacy statement</a>.</span>
           </li>
+          {ANALYTICS_ENABLED && (
+            <li class="flex items-start gap-2">
+              <span class="text-neon-cyan mt-0.5">&#9656;</span>
+              <span><strong class="text-text-bright">Cloudflare Web Analytics</strong> gives us aggregate, cookieless visitor counts. See their <a href="https://www.cloudflare.com/web-analytics/" class="text-neon-cyan hover:underline" target="_blank" rel="noopener noreferrer">privacy-first analytics</a>.</span>
+            </li>
+          )}
         </ul>
       </div>
 


### PR DESCRIPTION
## What

Adds cookieless, privacy-first visitor analytics (Cloudflare Web Analytics) that ship **only when a token is configured**. Default state = no analytics, exactly as today.

## How it stays honest

A new `src/consts.ts` holds the one flag (`ANALYTICS_ENABLED`) that **both** the beacon and the `/privacy` copy read. They can't drift:

| | Beacon script | Privacy "What we collect" | Cloudflare third-party line |
|---|---|---|---|
| **Token empty** (default) | not shipped | "Nothing. No cookies, no trackers, no analytics." | absent |
| **Token set** | ships on all pages | "...Cloudflare Web Analytics for aggregate page views only..." | present |

There's no way to ship the tracker while the page claims "no analytics."

## To enable later

Per the instructions in `consts.ts`: add the site in Cloudflare (Web Analytics → softcat.ai), then either set `PUBLIC_CF_BEACON_TOKEN` in the build env or paste the site token into `CF_BEACON_TOKEN_OVERRIDE`, and deploy.

## Verification

`npm run build` exits 0 in both states. Confirmed against built output:
- Token empty: 0 pages with beacon, "Nothing" copy renders.
- Token set: beacon on all 801 pages, privacy copy flips to disclose it.

## Files

- `src/consts.ts` (new) — single source of truth
- `src/layouts/BaseLayout.astro` — conditional beacon in `<head>`
- `src/pages/privacy.astro` — copy flips with the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)