### PR TITLE
feat: enable Cloudflare Web Analytics for softcat.ai

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,7 +8,7 @@
 //
 // While the token is empty, NOTHING is rendered: no beacon script ships, and the
 // /privacy page truthfully says "no analytics". The two stay in sync automatically.
-const CF_BEACON_TOKEN_OVERRIDE = '';
+const CF_BEACON_TOKEN_OVERRIDE = 'c0ed69cab5c240d1813af18a31734729';
 
 export const CF_BEACON_TOKEN: string =
   import.meta.env.PUBLIC_CF_BEACON_TOKEN || CF_BEACON_TOKEN_OVERRIDE;


### PR DESCRIPTION
Sets the live site token in `CF_BEACON_TOKEN_OVERRIDE`, flipping analytics from dormant to on.

- Beacon ships on all 801 pages.
- `/privacy` copy flips to disclose cookieless aggregate analytics; "Nothing" line removed.
- Token is public by design (renders client-side in the beacon), so no secret is committed.

Build verified green with the token set. Follow-on to #153, which added the opt-in mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)