### PR TITLE
Model roster: single source of truth + radar-gated proposals (plan PR 2/5)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,4 +22,12 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: node scripts/validate-tools-data.mjs
       - run: npm run build
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Bot unit tests
+        run: |
+          pip install -q pytest httpx python-dotenv
+          python -m pytest bot/tests/ -q

--- a/bot/model_data_bot.py
+++ b/bot/model_data_bot.py
@@ -52,33 +52,15 @@ MAX_AUTO_DELTA = 0.5
 # Fields eligible for the delta check. Non-numeric fields skip the guardrail.
 GUARDED_NUMERIC_FIELDS = {"contextK", "inputPrice", "outputPrice"}
 
-# OpenRouter model IDs we track. Add new IDs here to have the bot
-# pick them up automatically. Remove IDs to stop tracking.
-TRACKED_IDS = [
-    "anthropic/claude-opus-4",
-    "anthropic/claude-sonnet-4",
-    "anthropic/claude-haiku-4.5",
-    "openai/gpt-5",
-    "openai/gpt-5-mini",
-    "openai/gpt-5-nano",
-    "openai/gpt-4.1",
-    "openai/gpt-4o",
-    "openai/o3",
-    "openai/o3-mini",
-    "google/gemini-2.5-pro-preview",
-    "google/gemini-2.5-flash",
-    "google/gemini-2.0-flash-001",
-    "meta-llama/llama-4-scout",
-    "meta-llama/llama-4-maverick",
-    "deepseek/deepseek-chat-v3-0324",
-    "deepseek/deepseek-r1",
-    "mistralai/mistral-large-2512",
-    "mistralai/mistral-small-3.1-24b-instruct",
-    "qwen/qwen-2.5-72b-instruct",
-    "moonshotai/kimi-k2",
-]
+# The roster IS src/data/models.json (eng review E1). Job 1 refreshes
+# prices/specs for whatever ids that file contains. New models enter the
+# roster only through Job 2's proposal PRs (radar-gated), reviewed by Valori.
+# There is deliberately NO bootstrap path that can publish placeholder
+# entries to main.
 
-# Defaults for newly discovered models (manual fields)
+# Defaults for PROPOSED models (Job 2). These land only on a proposal
+# branch, clearly placeholder-marked, and are edited during PR review.
+# They are never committed to main by the bot.
 NEW_MODEL_DEFAULTS = {
     "family": "Unknown",
     "reasoning": False,
@@ -86,9 +68,17 @@ NEW_MODEL_DEFAULTS = {
     "coding": 70,
     "reasoning_score": 70,
     "speed": 70,
-    "description": "Newly added model. Capability scores are placeholder.",
-    "strengths": "Newly added",
+    "description": "PLACEHOLDER - edit before merge. Capability scores are editorial; set them during PR review.",
+    "strengths": "PLACEHOLDER - edit before merge",
 }
+
+PROPOSAL_BRANCH = "model-bot/roster-proposals"
+RADAR_DIR = REPO_DIR / "src" / "data" / "radar"
+
+
+class RadarDataError(RuntimeError):
+    """Radar day-files were missing or unparseable. Loud by design (D5/1A):
+    a broken trigger must never look like 'no notable models this month'."""
 
 PROVIDER_MAP = {
     "anthropic": "Anthropic",
@@ -99,13 +89,21 @@ PROVIDER_MAP = {
     "mistralai": "Mistral",
     "qwen": "Alibaba",
     "moonshotai": "Moonshot AI",
+    "x-ai": "xAI",
+    "z-ai": "Z.ai",
 }
 
 
 def load_models():
-    if MODELS_FILE.exists():
-        return json.loads(MODELS_FILE.read_text())
-    return []
+    """Load the roster. Missing or empty models.json is a LOUD failure
+    (eng E6.1) - with no TRACKED_IDS fallback an empty roster would
+    otherwise become a valid silent no-op."""
+    if not MODELS_FILE.exists():
+        raise RuntimeError(f"{MODELS_FILE} missing - roster is gone, refusing to run")
+    models = json.loads(MODELS_FILE.read_text())
+    if not isinstance(models, list) or not models:
+        raise RuntimeError(f"{MODELS_FILE} is empty or malformed - refusing to run")
+    return models
 
 
 def save_models(models):
@@ -213,28 +211,9 @@ def update_models(existing, api_models):
             # No API data for this model, keep as-is
             updated.append(model)
 
-    # Add new tracked models not yet in our data
-    existing_ids = {m.get("id", "") for m in existing}
-    for model_id in TRACKED_IDS:
-        if model_id not in existing_ids and model_id in api_models:
-            api_model = api_models[model_id]
-            # Strip "Provider: " prefix if present
-            raw_name = api_model.get("name", model_id)
-            name = raw_name.split(": ", 1)[-1] if ": " in raw_name else raw_name
-
-            auto_fields = extract_auto_fields(api_model)
-            new_model = {
-                "id": model_id,
-                "name": name,
-                "provider": derive_provider(model_id),
-                "released": date.today().strftime("%Y-%m"),
-                **NEW_MODEL_DEFAULTS,
-                **auto_fields,
-            }
-            print(f"  Added new model: {new_model['name']}")
-            updated.append(new_model)
-            changed = True
-
+    # NOTE: there is intentionally no "add new models" branch here (eng E1).
+    # Job 1 only refreshes entries already in models.json. New entries arrive
+    # via Job 2's reviewed proposal PRs.
     return updated, changed, suspects
 
 
@@ -293,6 +272,221 @@ def git_commit_and_push():
     )
 
 
+# --------------------------------------------------------------------------- #
+# Job 2: radar-gated roster proposals (B4 / D4 / D11 / E4)                     #
+#                                                                              #
+#   radar day-files ──▶ normalized-name match ──▶ OpenRouter id               #
+#        │ (loud fail on        │ (pure fn,            │ not in models.json   #
+#        │  malformed/0 files)  │  table-tested)       ▼                      #
+#        │                      │              proposal entry (placeholder-   #
+#        ▼                      ▼              marked) ──▶ commit on top of   #
+#   RadarDataError       no match = no       existing PR branch (never        #
+#   + exit non-zero      proposal (fine)     force-push) ──▶ gh pr outside    #
+#                                            git lock ──▶ Discord ping        #
+# --------------------------------------------------------------------------- #
+
+def normalize_name(s: str) -> str:
+    """Lowercase, strip everything but [a-z0-9]. Deterministic join key
+    between radar entry names and OpenRouter model names (eng E4)."""
+    import re
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+def names_match(radar_name: str, or_name: str) -> bool:
+    """Bidirectional substring on normalized names. >=6 chars to avoid
+    junk matches like 'ai' or 'gpt'."""
+    rn, on = normalize_name(radar_name), normalize_name(or_name.split(": ", 1)[-1])
+    # >=5 chars on both sides: blocks junk ("ai", "o3", "gpt") while letting
+    # short real names ("gpt55") through. Every match is still human-reviewed.
+    if len(rn) < 5 or len(on) < 5:
+        return False
+    return rn in on or on in rn
+
+
+def scan_radar_entries() -> list[dict]:
+    """Read all radar day-files. Returns [{name, date, entry_id}, ...].
+    LOUD on malformed JSON or zero readable files (D5/1A)."""
+    files = sorted(RADAR_DIR.glob("2026-*.json")) + sorted(RADAR_DIR.glob("202[7-9]-*.json"))
+    if not files:
+        raise RadarDataError(f"no radar day-files found in {RADAR_DIR}")
+    out = []
+    for f in files:
+        try:
+            day = json.loads(f.read_text())
+        except (json.JSONDecodeError, ValueError) as e:
+            raise RadarDataError(f"radar file {f.name} unparseable: {e}")
+        if not isinstance(day, dict):
+            raise RadarDataError(f"radar file {f.name} is not an object")
+        date_str = day.get("date", f.stem)
+        for section in ("featured", "items", "launches"):
+            for item in day.get(section) or []:
+                if isinstance(item, dict) and item.get("name"):
+                    out.append({"name": item["name"], "date": date_str,
+                                "entry_id": item.get("id", "")})
+    if not out:
+        raise RadarDataError("radar files parsed but contained zero entries")
+    return out
+
+
+def find_roster_candidates(existing_ids: set, api_models: dict,
+                           radar_entries: list[dict]) -> list[dict]:
+    """The gate: on OpenRouter AND radar-featured AND not already tracked.
+    Skips :free/-fast variant ids when the base id also matches."""
+    candidates = {}
+    for r in radar_entries:
+        for mid, api_model in api_models.items():
+            if mid in existing_ids or ":" in mid:
+                continue
+            if names_match(r["name"], api_model.get("name", mid)):
+                prev = candidates.get(mid)
+                if not prev or r["date"] > prev["radar_date"]:
+                    candidates[mid] = {"model_id": mid, "radar_name": r["name"],
+                                       "radar_date": r["date"], "radar_entry_id": r["entry_id"]}
+    # prefer base ids over longer variants of the same family (e.g. -fast)
+    ids = set(candidates)
+    return [c for mid, c in sorted(candidates.items())
+            if not any(other != mid and mid.startswith(other) for other in ids)]
+
+
+def build_proposal_entry(cand: dict, api_models: dict) -> dict:
+    api_model = api_models[cand["model_id"]]
+    raw_name = api_model.get("name", cand["model_id"])
+    name = raw_name.split(": ", 1)[-1] if ": " in raw_name else raw_name
+    return {
+        "id": cand["model_id"],
+        "name": name,
+        "provider": derive_provider(cand["model_id"]),
+        "released": date.today().strftime("%Y-%m"),
+        **NEW_MODEL_DEFAULTS,
+        **extract_auto_fields(api_model),
+        "trackedSince": date.today().isoformat(),
+        "radarRef": f"{cand['radar_date']}#{cand['radar_entry_id']}",
+    }
+
+
+def post_roster_pr_to_discord(pr_url: str, entries: list[dict]):
+    webhook = os.environ.get("DISCORD_WEBHOOK_MODEL_DATA")
+    if not webhook:
+        return
+    names = ", ".join(e["name"] for e in entries)
+    try:
+        httpx.post(webhook, json={
+            "content": f"**Model bot:** roster proposal PR for {names}\n"
+                       f"Edit the placeholder scores before merging: {pr_url}",
+            "username": "SOFT CAT Model Data"}, timeout=15)
+    except Exception as e:
+        print(f"[model_bot] Discord post failed: {e}")
+
+
+def propose_roster_pr(entries: list[dict]) -> str | None:
+    """Open or update the single roster proposal PR.
+
+    D11/E6.5: new proposals land as commits ON TOP of the existing open PR
+    branch (preserves human edits + review discussion). Never checkout -B
+    over a remote branch, never force-push. gh network calls run OUTSIDE
+    the git lock (E6.6). The tree is ALWAYS checked back to main (E6.4).
+    """
+    if not entries:
+        return None
+    os.chdir(REPO_DIR)
+
+    # gh queries outside the lock
+    existing_pr = None
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--head", PROPOSAL_BRANCH, "--state", "open",
+             "--json", "number,url", "--limit", "1"],
+            capture_output=True, text=True, check=True)
+        prs = json.loads(result.stdout)
+        if prs:
+            existing_pr = prs[0]
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        pass
+
+    pushed = False
+    added = []
+    with git_safe.git_lock():
+        git_safe.check_repo_health()
+        try:
+            subprocess.run(["git", "fetch", "origin", "main", PROPOSAL_BRANCH],
+                           capture_output=True)  # branch may not exist yet
+            remote_branch = subprocess.run(
+                ["git", "rev-parse", "--verify", f"origin/{PROPOSAL_BRANCH}"],
+                capture_output=True).returncode == 0
+            if remote_branch and existing_pr:
+                # continue the open PR's branch - append, never rewrite
+                subprocess.run(["git", "checkout", "-B", PROPOSAL_BRANCH,
+                                f"origin/{PROPOSAL_BRANCH}"], check=True, capture_output=True)
+            else:
+                subprocess.run(["git", "checkout", "-B", PROPOSAL_BRANCH,
+                                "origin/main"], check=True, capture_output=True)
+
+            current = json.loads(MODELS_FILE.read_text())
+            branch_ids = {m.get("id") for m in current}
+            added = [e for e in entries if e["id"] not in branch_ids]
+            if not added:
+                print("[model_bot] all candidates already proposed on branch")
+                return existing_pr["url"] if existing_pr else None
+
+            current.extend(added)
+            current.sort(key=lambda m: (m.get("provider", ""), m.get("name", "")))
+            MODELS_FILE.write_text(json.dumps(current, indent=2) + "\n")
+            names = ", ".join(e["name"] for e in added)
+            subprocess.run(["git", "add", str(MODELS_FILE)], check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m",
+                            f"bot(model): propose roster addition - {names}"],
+                           check=True, capture_output=True)
+            subprocess.run(["git", "push", "origin", PROPOSAL_BRANCH],
+                           check=True, capture_output=True)
+            pushed = True
+        finally:
+            # the shared working tree must NEVER be left on a branch (E6.4)
+            subprocess.run(["git", "checkout", "main"], capture_output=True)
+
+    if not pushed:
+        return existing_pr["url"] if existing_pr else None
+
+    # gh mutations outside the lock (E6.6)
+    if existing_pr:
+        body = "New roster candidate(s) appended: " + ", ".join(e["name"] for e in added)
+        subprocess.run(["gh", "pr", "comment", str(existing_pr["number"]),
+                        "--body", body], capture_output=True)
+        pr_url = existing_pr["url"]
+    else:
+        lines = [f"- **{e['name']}** (`{e['id']}`) - radar: {e['radarRef']}" for e in added]
+        body = ("## Roster proposal (radar-gated)\n\n" + "\n".join(lines) +
+                "\n\nScores are PLACEHOLDER - assign editorial scores during review, "
+                "then merge. Trigger: model on OpenRouter AND featured on Radar AND "
+                "not in models.json.\n\n---\nGenerated by `model_data_bot.py` Job 2.")
+        result = subprocess.run(
+            ["gh", "pr", "create", "--base", "main", "--head", PROPOSAL_BRANCH,
+             "--title", f"Model roster: {', '.join(e['name'] for e in added)}",
+             "--body", body], capture_output=True, text=True, check=True)
+        pr_url = result.stdout.strip().splitlines()[-1]
+
+    post_roster_pr_to_discord(pr_url, added)
+    return pr_url
+
+
+def run_roster_job(existing: list[dict], api_models: dict, t0: float):
+    """Job 2 entry point. Loud on radar data errors; quiet when there is
+    simply nothing to propose."""
+    radar_entries = scan_radar_entries()
+    existing_ids = {m.get("id", "") for m in existing}
+    candidates = find_roster_candidates(existing_ids, api_models, radar_entries)
+    if not candidates:
+        print("[model_bot] roster: no new radar-gated candidates")
+        log_run("model_bot", status="success", duration_s=_time.time() - t0,
+                items_found=len(radar_entries), items_published=0, job="roster")
+        return
+    entries = [build_proposal_entry(c, api_models) for c in candidates]
+    pr_url = propose_roster_pr(entries)
+    print(f"[model_bot] roster proposal: {pr_url}")
+    log_run("model_bot", status="success", duration_s=_time.time() - t0,
+            items_found=len(radar_entries), items_published=len(entries),
+            output_files=[pr_url or ""], job="roster")
+
+
 def ping_healthcheck(status="success"):
     """Ping Healthchecks.io to report bot status."""
     url = os.environ.get("HC_PING_MODEL_DATA")
@@ -311,7 +505,10 @@ def main():
 
     try:
         # Self-heal: clear any uncommitted drift before we read baseline.
-        reset_drifted_baseline()
+        # Under the shared git lock (eng E6.3) so it can't race another
+        # bot's branch work in the same working tree.
+        with git_safe.git_lock():
+            reset_drifted_baseline()
 
         existing = load_models()
         print(f"Loaded {len(existing)} existing models")
@@ -335,37 +532,43 @@ def main():
             write_suspects(suspects)
             post_suspects_to_discord(suspects)
 
-        if not changed:
-            print("No changes detected. Exiting.")
-            # Log BEFORE any commit step so the runs.json entry lands with
-            # any concurrent bot's commit instead of a future one (#97).
+        if changed:
+            print(f"Saving {len(updated)} models...")
+            save_models(updated)
+
+            # Log BEFORE commit so the runs.json entry lands in the same commit
+            # as models.json (#97 fix). If commit fails, the log still reflects
+            # what we tried to ship and surfaces the problem on the dashboard.
             log_run("model_bot", status="success", duration_s=_time.time() - t0,
-                    items_found=len(api_models), items_published=0)
-            ping_healthcheck()
-            sys.exit(0)
+                    items_found=len(api_models), items_published=len(updated),
+                    output_files=["src/data/models.json"], job="prices")
 
-        print(f"Saving {len(updated)} models...")
-        save_models(updated)
-
-        # Log BEFORE commit so the runs.json entry lands in the same commit
-        # as models.json (#97 fix). If commit fails, the log still reflects
-        # what we tried to ship and surfaces the problem on the dashboard.
-        log_run("model_bot", status="success", duration_s=_time.time() - t0,
-                items_found=len(api_models), items_published=len(updated),
-                output_files=["src/data/models.json"])
-
-        print("Committing and pushing...")
-        git_commit_and_push()
-
-        print("Done.")
-        ping_healthcheck()
+            print("Committing and pushing...")
+            git_commit_and_push()
+        else:
+            print("No price/spec changes detected.")
+            log_run("model_bot", status="success", duration_s=_time.time() - t0,
+                    items_found=len(api_models), items_published=0, job="prices")
 
     except Exception as e:
-        print(f"Bot failed: {e}")
+        print(f"Bot failed (prices job): {e}")
         log_run("model_bot", status="error", duration_s=_time.time() - t0,
-                error_msg=str(e))
+                error_msg=str(e), job="prices")
         ping_healthcheck("fail")
         sys.exit(1)
+
+    # ---- Job 2: roster proposals (failures are loud but independent of Job 1)
+    try:
+        run_roster_job(updated if changed else existing, api_models, t0)
+    except Exception as e:
+        print(f"Bot failed (roster job): {e}")
+        log_run("model_bot", status="error", duration_s=_time.time() - t0,
+                error_msg=str(e), job="roster")
+        ping_healthcheck("fail")
+        sys.exit(1)
+
+    print("Done.")
+    ping_healthcheck()
 
 
 if __name__ == "__main__":

--- a/bot/pipeline_log.py
+++ b/bot/pipeline_log.py
@@ -55,8 +55,13 @@ def log_run(
     output_tokens: int = 0,
     output_files: list[str] | None = None,
     error_msg: str = "",
+    job: str = "",
 ) -> None:
-    """Append a run entry to runs.json with file locking."""
+    """Append a run entry to runs.json with file locking.
+
+    `job` optionally distinguishes sub-jobs of one bot (e.g. model_bot's
+    "prices" vs "roster") without registering new bot ids - the site's
+    "six bots" copy stays true (eng D8/4A)."""
     entry = {
         "bot": bot,
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -74,6 +79,8 @@ def log_run(
     }
     if error_msg:
         entry["error_msg"] = error_msg
+    if job:
+        entry["job"] = job
 
     # Ensure directory exists
     RUNS_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Make bot/ modules importable from bot/tests/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/bot/tests/test_job1_regression.py
+++ b/bot/tests/test_job1_regression.py
@@ -1,0 +1,81 @@
+"""CRITICAL regression tests (eng E1): the models.json-as-roster refactor
+must not change Job 1's merge behaviour for existing entries.
+
+Pinned behaviours: lockedFields honoured, >MAX_AUTO_DELTA swings routed to
+suspects (not landed), openSource entries skip price updates, and the old
+bootstrap path is GONE (an OpenRouter id absent from models.json is never
+added by Job 1).
+"""
+import model_data_bot as bot
+
+
+def api_model(prompt="0.000003", completion="0.000015", ctx=200000, modalities=None):
+    return {
+        "pricing": {"prompt": prompt, "completion": completion},
+        "context_length": ctx,
+        "architecture": {"input_modalities": modalities or ["text"]},
+    }
+
+
+BASE = {
+    "id": "anthropic/claude-sonnet-4", "name": "Claude Sonnet 4.5",
+    "provider": "Anthropic", "released": "2025-10", "contextK": 200,
+    "inputPrice": 3, "outputPrice": 15, "openSource": False,
+    "multimodal": False, "coding": 92, "reasoning_score": 93, "speed": 70,
+}
+
+
+def test_price_refresh_lands_small_changes():
+    existing = [dict(BASE)]
+    api = {"anthropic/claude-sonnet-4": api_model(prompt="0.0000035")}  # 3.0 -> 3.5
+    updated, changed, suspects = bot.update_models(existing, api)
+    assert changed is True
+    assert suspects == []
+    assert updated[0]["inputPrice"] == 3.5
+
+
+def test_locked_fields_never_change():
+    existing = [dict(BASE, lockedFields=["contextK"])]
+    api = {"anthropic/claude-sonnet-4": api_model(ctx=1000000)}
+    updated, _, suspects = bot.update_models(existing, api)
+    assert updated[0]["contextK"] == 200
+    assert all(s["field"] != "contextK" for s in suspects)
+
+
+def test_big_delta_goes_to_suspects_not_data():
+    existing = [dict(BASE)]
+    api = {"anthropic/claude-sonnet-4": api_model(prompt="0.00002")}  # 3 -> 20 (>50%)
+    updated, changed, suspects = bot.update_models(existing, api)
+    assert updated[0]["inputPrice"] == 3
+    assert len(suspects) == 1
+    assert suspects[0]["field"] == "inputPrice"
+    assert suspects[0]["proposed"] == 20.0
+
+
+def test_open_source_skips_prices():
+    existing = [dict(BASE, id="z-ai/glm-5", openSource=True, inputPrice=0, outputPrice=0)]
+    api = {"z-ai/glm-5": api_model(prompt="0.0000006", completion="0.00000192")}
+    updated, changed, _ = bot.update_models(existing, api)
+    assert updated[0]["inputPrice"] == 0
+    assert updated[0]["outputPrice"] == 0
+
+
+def test_no_bootstrap_of_untracked_ids():
+    """THE E1 invariant: Job 1 never adds entries, even when OpenRouter
+    has a model that models.json lacks."""
+    existing = [dict(BASE)]
+    api = {
+        "anthropic/claude-sonnet-4": api_model(),
+        "some-lab/brand-new-model": api_model(),
+    }
+    updated, _, _ = bot.update_models(existing, api)
+    assert len(updated) == 1
+    assert {m["id"] for m in updated} == {"anthropic/claude-sonnet-4"}
+
+
+def test_missing_api_data_keeps_entry_untouched():
+    existing = [dict(BASE)]
+    updated, changed, suspects = bot.update_models(existing, {})
+    assert updated == existing
+    assert changed is False
+    assert suspects == []

--- a/bot/tests/test_matcher.py
+++ b/bot/tests/test_matcher.py
@@ -1,0 +1,41 @@
+"""Table-driven tests for the radar↔OpenRouter name matcher (eng E4).
+
+The matcher is the join key for roster discovery. Known-tricky real cases
+are pinned here, including the documented miss (Gemini Live Translate is a
+product entry, not a model entry — it must NOT match gemini-3.5-flash; that
+addition was editorial, not bot-discovered).
+"""
+import pytest
+
+from model_data_bot import normalize_name, names_match
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("Claude Fable 5", "claudefable5"),
+    ("GPT-5.5 Instant", "gpt55instant"),
+    ("Qwen3.6-27B", "qwen3627b"),
+    ("  MiniMax  M2.7 ", "minimaxm27"),
+    ("", ""),
+])
+def test_normalize_name(raw, expected):
+    assert normalize_name(raw) == expected
+
+
+@pytest.mark.parametrize("radar,openrouter,match", [
+    # real hits from production data (2026-06-10 run)
+    ("Claude Fable 5", "Anthropic: Claude Fable 5", True),
+    ("GPT-5.5 Instant", "OpenAI: GPT-5.5", True),
+    ("Grok 4.3", "xAI: Grok 4.3", True),
+    ("Claude Opus 4.7", "Anthropic: Claude Opus 4.7", True),
+    ("Kimi K2.6", "MoonshotAI: Kimi K2.6", True),
+    ("Mistral Small 4", "Mistral: Mistral Small 4", True),
+    # documented miss: product entry vs model name — editorial add only
+    ("Gemini 3.5 Live Translate", "Google: Gemini 3.5 Flash", False),
+    # junk-match guards: too short after normalization
+    ("GPT", "OpenAI: GPT-5.5", False),  # 3 chars, junk guard
+    ("AI", "Mistral: Mistral Small 4", False),
+    # unrelated
+    ("Claude Fable 5", "OpenAI: GPT-5.5", False),
+])
+def test_names_match(radar, openrouter, match):
+    assert names_match(radar, openrouter) is match

--- a/bot/tests/test_trigger.py
+++ b/bot/tests/test_trigger.py
@@ -1,0 +1,83 @@
+"""Roster trigger gate tests (B4/D4): on OpenRouter AND radar-featured AND
+not already tracked. Plus the loud-failure contract for radar data (D5/1A).
+"""
+import json
+
+import pytest
+
+import model_data_bot as bot
+
+
+API = {
+    "anthropic/claude-fable-5": {"name": "Anthropic: Claude Fable 5",
+                                 "pricing": {"prompt": "0.00001", "completion": "0.00005"},
+                                 "context_length": 1000000,
+                                 "architecture": {"input_modalities": ["text", "image"]}},
+    "anthropic/claude-fable-5:free": {"name": "Anthropic: Claude Fable 5 (free)",
+                                      "pricing": {}, "context_length": 1000000,
+                                      "architecture": {}},
+    "openai/gpt-5.5": {"name": "OpenAI: GPT-5.5", "pricing": {},
+                       "context_length": 1050000, "architecture": {}},
+}
+RADAR = [
+    {"name": "Claude Fable 5", "date": "2026-06-10", "entry_id": "ph-claude-fable-5"},
+    {"name": "Some Unrelated Product", "date": "2026-06-09", "entry_id": "ph-x"},
+]
+
+
+def test_gate_proposes_radar_and_openrouter_match():
+    cands = bot.find_roster_candidates(set(), API, RADAR)
+    ids = [c["model_id"] for c in cands]
+    assert "anthropic/claude-fable-5" in ids
+    # :free variant suppressed in favour of the base id
+    assert "anthropic/claude-fable-5:free" not in ids
+    # on OpenRouter but never on radar -> not proposed
+    assert "openai/gpt-5.5" not in ids
+
+
+def test_gate_skips_already_tracked():
+    cands = bot.find_roster_candidates({"anthropic/claude-fable-5"}, API, RADAR)
+    assert cands == []
+
+
+def test_gate_keeps_latest_radar_date():
+    radar = RADAR + [{"name": "Claude Fable 5", "date": "2026-06-01", "entry_id": "ph-old"}]
+    cands = bot.find_roster_candidates(set(), API, radar)
+    assert cands[0]["radar_date"] == "2026-06-10"
+    assert cands[0]["radar_entry_id"] == "ph-claude-fable-5"
+
+
+def test_proposal_entry_is_placeholder_marked():
+    cand = bot.find_roster_candidates(set(), API, RADAR)[0]
+    entry = bot.build_proposal_entry(cand, API)
+    assert entry["id"] == "anthropic/claude-fable-5"
+    assert "PLACEHOLDER" in entry["description"]
+    assert entry["radarRef"] == "2026-06-10#ph-claude-fable-5"
+    assert entry["contextK"] == 1000
+    assert entry["multimodal"] is True
+
+
+def test_radar_scan_loud_on_malformed_file(tmp_path, monkeypatch):
+    (tmp_path / "2026-06-10.json").write_text("{not json")
+    monkeypatch.setattr(bot, "RADAR_DIR", tmp_path)
+    with pytest.raises(bot.RadarDataError):
+        bot.scan_radar_entries()
+
+
+def test_radar_scan_loud_on_zero_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot, "RADAR_DIR", tmp_path)
+    with pytest.raises(bot.RadarDataError):
+        bot.scan_radar_entries()
+
+
+def test_radar_scan_loud_on_zero_entries(tmp_path, monkeypatch):
+    (tmp_path / "2026-06-10.json").write_text(json.dumps({"date": "2026-06-10", "featured": []}))
+    monkeypatch.setattr(bot, "RADAR_DIR", tmp_path)
+    with pytest.raises(bot.RadarDataError):
+        bot.scan_radar_entries()
+
+
+def test_radar_scan_reads_real_repo_data():
+    entries = bot.scan_radar_entries()
+    assert len(entries) > 50
+    assert any(e["entry_id"] == "ph-claude-fable-5" for e in entries)

--- a/scripts/validate-tools-data.mjs
+++ b/scripts/validate-tools-data.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Tools-data validator (eng D7/3A + E5 CI wiring).
+// Checks src/data/models.json and src/data/tools-manifest.json beyond what
+// the Astro build can see (models.json is imported as plain JSON, so schema
+// drift would otherwise ship silently).
+//
+// Errors exit 1 (block merge). radarRef pointing at a PRUNED radar day-file
+// is a WARNING only — pruning is expected (PR #143) and the build degrades
+// the link to plain text by design.
+//
+// Run: node scripts/validate-tools-data.mjs   (wired into validate.yml)
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const errors = [];
+const warnings = [];
+
+const ISO_DATE = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+const RADAR_REF = /^(\d{4}-\d{2}-\d{2})#(.+)$/;
+const YEAR_MONTH = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+// ---- models.json -----------------------------------------------------------
+const models = JSON.parse(readFileSync(join(root, 'src/data/models.json'), 'utf8'));
+if (!Array.isArray(models) || models.length === 0) {
+  errors.push('models.json: must be a non-empty array');
+}
+const seen = new Set();
+for (const m of models) {
+  const at = `models.json[${m.id ?? '?'}]`;
+  for (const k of ['id', 'name', 'provider', 'released', 'description', 'strengths']) {
+    if (typeof m[k] !== 'string' || !m[k]) errors.push(`${at}: missing string field "${k}"`);
+  }
+  if (seen.has(m.id)) errors.push(`${at}: duplicate id`);
+  seen.add(m.id);
+  if (m.released && !YEAR_MONTH.test(m.released)) errors.push(`${at}: released must be YYYY-MM`);
+  if (!ISO_DATE.test(m.trackedSince ?? '')) errors.push(`${at}: trackedSince must be YYYY-MM-DD`);
+  for (const k of ['coding', 'reasoning_score', 'speed']) {
+    if (!Number.isFinite(m[k]) || m[k] < 0 || m[k] > 100) errors.push(`${at}: ${k} must be 0-100`);
+  }
+  for (const k of ['inputPrice', 'outputPrice']) {
+    if (!Number.isFinite(m[k]) || m[k] < 0) errors.push(`${at}: ${k} must be a number >= 0`);
+  }
+  if (!Number.isInteger(m.contextK) || m.contextK < 0) errors.push(`${at}: contextK must be a non-negative integer`);
+  for (const k of ['openSource', 'reasoning', 'multimodal']) {
+    if (typeof m[k] !== 'boolean') errors.push(`${at}: ${k} must be boolean`);
+  }
+  if (m.description?.includes('PLACEHOLDER') || m.strengths?.includes('PLACEHOLDER')) {
+    errors.push(`${at}: PLACEHOLDER text must be edited before merge`);
+  }
+  if (m.radarRef !== undefined) {
+    const match = RADAR_REF.exec(m.radarRef);
+    if (!match) {
+      errors.push(`${at}: radarRef must be "YYYY-MM-DD#entry-id"`);
+    } else {
+      const dayFile = join(root, 'src/data/radar', `${match[1]}.json`);
+      if (!existsSync(dayFile)) {
+        warnings.push(`${at}: radarRef day-file ${match[1]}.json pruned — link degrades to text`);
+      } else {
+        const day = JSON.parse(readFileSync(dayFile, 'utf8'));
+        const ids = ['featured', 'items', 'launches']
+          .flatMap((s) => day[s] ?? [])
+          .map((e) => e.id);
+        if (!ids.includes(match[2])) errors.push(`${at}: radarRef entry "${match[2]}" not in ${match[1]}.json`);
+      }
+    }
+  }
+}
+
+// ---- tools-manifest.json ----------------------------------------------------
+const manifest = JSON.parse(readFileSync(join(root, 'src/data/tools-manifest.json'), 'utf8'));
+if (!Array.isArray(manifest) || manifest.length === 0) errors.push('tools-manifest.json: must be a non-empty array');
+for (const t of manifest) {
+  const at = `tools-manifest.json[${t.id ?? '?'}]`;
+  for (const k of ['id', 'name', 'description', 'stat', 'href', 'icon', 'category']) {
+    if (typeof t[k] !== 'string' || !t[k]) errors.push(`${at}: missing string field "${k}"`);
+  }
+  if (!ISO_DATE.test(t.addedDate ?? '')) errors.push(`${at}: addedDate must be YYYY-MM-DD`);
+  if (t.dataSource !== undefined && t.dataSource !== 'models.json') {
+    errors.push(`${at}: dataSource must be "models.json" when present`);
+  }
+}
+
+for (const w of warnings) console.warn(`WARN  ${w}`);
+for (const e of errors) console.error(`ERROR ${e}`);
+console.log(`validate-tools-data: ${models.length} models, ${manifest.length} tools — ${errors.length} error(s), ${warnings.length} warning(s)`);
+process.exit(errors.length ? 1 : 0);

--- a/src/components/lab/ModelComparison.tsx
+++ b/src/components/lab/ModelComparison.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import modelsData from '../../data/models.json';
+import radarIndex from '../../data/radar/index.json';
 
 interface Model {
   name: string;
@@ -13,9 +14,26 @@ interface Model {
   coding: number;
   reasoning_score: number;
   speed: number;
+  trackedSince?: string;
+  radarRef?: string;
 }
 
 const models: Model[] = modelsData as Model[];
+
+// Radar day-files are pruned as they age out of the manifest (PR #143) —
+// a radarRef whose day is gone renders nothing, never a dead link (E2).
+const liveRadarDates = new Set<string>((radarIndex as { dates: string[] }).dates);
+
+const NEWLY_TRACKED_DAYS = 14;
+export const isNewlyTracked = (trackedSince?: string) =>
+  !!trackedSince && Date.now() - new Date(trackedSince).getTime() < NEWLY_TRACKED_DAYS * 86400_000;
+
+export function radarLink(radarRef?: string): { date: string; href: string } | null {
+  if (!radarRef) return null;
+  const date = radarRef.split('#')[0];
+  if (!liveRadarDates.has(date)) return null;
+  return { date, href: `/radar/${date}` };
+}
 
 const ctxDisplay = (k: number) => k >= 1000 ? `${k / 1000}M` : `${k}K`;
 const priceDisplay = (p: number) => p === 0 ? 'Free*' : `$${p}`;
@@ -112,9 +130,23 @@ export default function ModelComparison() {
           <tbody>
             {filtered.map((m) => (
               <tr class="border-b border-surface-light/30 hover:bg-surface-light/20 transition-colors">
-                <td class="py-2.5 px-3 font-mono text-sm text-text-bright">
+                <td class="py-2.5 px-3 font-mono text-sm text-text-bright whitespace-nowrap">
+                  {isNewlyTracked(m.trackedSince) && (
+                    <span
+                      class="inline-block w-1.5 h-1.5 rounded-full bg-neon-cyan motion-safe:animate-pulse mr-2 align-middle"
+                      title={`newly tracked since ${m.trackedSince}`}
+                    />
+                  )}
                   {m.name}
                   {m.openSource && <span class="ml-2 text-xs text-neon-green">OSS</span>}
+                  {radarLink(m.radarRef) && (
+                    <a
+                      href={radarLink(m.radarRef)!.href}
+                      class="ml-2 text-xs no-underline hover:underline"
+                      style="color: #ff3366"
+                      title={`seen on Radar ${radarLink(m.radarRef)!.date}`}
+                    >◉</a>
+                  )}
                 </td>
                 <td class="py-2.5 px-3 font-mono text-sm text-text-muted">{m.provider}</td>
                 <td class="py-2.5 px-3 font-mono text-sm text-neon-cyan">{ctxDisplay(m.contextK)}</td>
@@ -132,6 +164,9 @@ export default function ModelComparison() {
 
       <p class="font-mono text-xs text-text-muted">
         {filtered.length} of {models.length} models shown. Prices per 1M tokens (USD). *Open source models are free to self-host.
+      </p>
+      <p class="font-mono text-xs text-text-muted/70">
+        scores: editorial, calibrated against public benchmarks &middot; ◉ = seen on the Radar
       </p>
     </div>
   );

--- a/src/components/lab/ModelExplorer.tsx
+++ b/src/components/lab/ModelExplorer.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import modelsData from '../../data/models.json';
+import { isNewlyTracked, radarLink } from './ModelComparison';
 
 interface ModelData {
   name: string;
@@ -16,6 +17,8 @@ interface ModelData {
   reasoning_score: number;
   speed: number;
   description: string;
+  trackedSince?: string;
+  radarRef?: string;
 }
 
 const allModels: ModelData[] = modelsData as ModelData[];
@@ -37,7 +40,15 @@ function ModelCard({ model }: { model: ModelData }) {
     <div class="bg-surface border border-surface-light rounded-lg p-4 card-glow space-y-3">
       <div class="flex items-start justify-between">
         <div>
-          <h3 class="font-mono text-sm font-bold text-text-bright">{model.name}</h3>
+          <h3 class="font-mono text-sm font-bold text-text-bright">
+            {isNewlyTracked(model.trackedSince) && (
+              <span
+                class="inline-block w-1.5 h-1.5 rounded-full bg-neon-cyan motion-safe:animate-pulse mr-2 align-middle"
+                title={`newly tracked since ${model.trackedSince}`}
+              />
+            )}
+            {model.name}
+          </h3>
           <div class="flex items-center gap-2 mt-1">
             <span class="font-mono text-xs text-text-muted">{model.provider}</span>
             {model.openSource && <span class="font-mono text-xs text-neon-green bg-neon-green/10 px-1.5 py-0.5 rounded">OSS</span>}
@@ -71,8 +82,16 @@ function ModelCard({ model }: { model: ModelData }) {
         </div>
       </div>
 
-      <div class="font-mono text-xs text-text-muted pt-1 border-t border-surface-light">
-        {priceStr} <span class="text-text-muted/50">per 1M tokens (in/out)</span>
+      <div class="font-mono text-xs text-text-muted pt-1 border-t border-surface-light flex items-center justify-between">
+        <span>{priceStr} <span class="text-text-muted/50">per 1M tokens (in/out)</span></span>
+        {radarLink(model.radarRef) && (
+          <a
+            href={radarLink(model.radarRef)!.href}
+            class="no-underline hover:underline"
+            style="color: #ff3366"
+            title={`seen on Radar ${radarLink(model.radarRef)!.date}`}
+          >◉ radar</a>
+        )}
       </div>
     </div>
   );

--- a/src/data/models.json
+++ b/src/data/models.json
@@ -15,7 +15,28 @@
     "reasoning_score": 75,
     "speed": 60,
     "description": "Top-tier Chinese open-source model. Strong at coding and multilingual tasks.",
-    "strengths": "Strong multilingual, coding, open weights"
+    "strengths": "Strong multilingual, coding, open weights",
+    "trackedSince": "2026-02-23"
+  },
+  {
+    "id": "anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "provider": "Anthropic",
+    "family": "Claude Mythos",
+    "released": "2026-06",
+    "contextK": 1000,
+    "inputPrice": 10.0,
+    "outputPrice": 50.0,
+    "openSource": false,
+    "reasoning": true,
+    "multimodal": true,
+    "coding": 98,
+    "reasoning_score": 99,
+    "speed": 45,
+    "description": "Anthropic's Mythos-class flagship with adaptive reasoning. Tops the Artificial Analysis index at launch.",
+    "strengths": "Frontier reasoning, 1M context, adaptive effort",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-06-10#ph-claude-fable-5"
   },
   {
     "id": "anthropic/claude-haiku-4.5",
@@ -33,7 +54,8 @@
     "reasoning_score": 75,
     "speed": 95,
     "description": "Fastest Claude model. Great for high-volume, latency-sensitive applications.",
-    "strengths": "Speed, cost efficiency, high volume"
+    "strengths": "Speed, cost efficiency, high volume",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "anthropic/claude-opus-4",
@@ -51,7 +73,28 @@
     "reasoning_score": 98,
     "speed": 40,
     "description": "Most capable Claude model. Excels at complex reasoning, agentic tasks, and extended coding.",
-    "strengths": "Most capable Claude, complex reasoning, agentic tasks"
+    "strengths": "Most capable Claude, complex reasoning, agentic tasks",
+    "trackedSince": "2026-02-23"
+  },
+  {
+    "id": "anthropic/claude-opus-4.7",
+    "name": "Claude Opus 4.7",
+    "provider": "Anthropic",
+    "family": "Claude 4",
+    "released": "2026-04",
+    "contextK": 1000,
+    "inputPrice": 5.0,
+    "outputPrice": 25.0,
+    "openSource": false,
+    "reasoning": true,
+    "multimodal": true,
+    "coding": 97,
+    "reasoning_score": 97,
+    "speed": 50,
+    "description": "Opus-class reasoning at a third of the old Opus price, with the context window stretched to 1M.",
+    "strengths": "Deep reasoning, 1M context, agentic coding",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-04-20#ph-claude-opus-4-7"
   },
   {
     "id": "anthropic/claude-sonnet-4",
@@ -72,7 +115,8 @@
     "strengths": "Near-Opus intelligence at Sonnet pricing",
     "lockedFields": [
       "contextK"
-    ]
+    ],
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "deepseek/deepseek-r1",
@@ -90,7 +134,8 @@
     "reasoning_score": 90,
     "speed": 35,
     "description": "Open-source reasoning model. Competes with o1 at a fraction of the cost.",
-    "strengths": "Open-source reasoning, competes with o1"
+    "strengths": "Open-source reasoning, competes with o1",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "deepseek/deepseek-chat-v3-0324",
@@ -108,7 +153,8 @@
     "reasoning_score": 82,
     "speed": 70,
     "description": "Strong general-purpose model at extremely low cost. Open weights.",
-    "strengths": "Cheap, strong general-purpose, open weights"
+    "strengths": "Cheap, strong general-purpose, open weights",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "google/gemini-2.0-flash-001",
@@ -126,7 +172,8 @@
     "reasoning_score": 75,
     "speed": 92,
     "description": "Rock-bottom pricing with 1M context. Fast multimodal processing.",
-    "strengths": "Rock-bottom pricing, speed, multimodal"
+    "strengths": "Rock-bottom pricing, speed, multimodal",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "google/gemini-2.5-flash",
@@ -144,7 +191,8 @@
     "reasoning_score": 82,
     "speed": 88,
     "description": "Cheap thinking model with 1M context. Excellent value for reasoning tasks.",
-    "strengths": "Cheap thinking model, massive context"
+    "strengths": "Cheap thinking model, massive context",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "google/gemini-2.5-pro-preview",
@@ -162,7 +210,28 @@
     "reasoning_score": 90,
     "speed": 55,
     "description": "Google's thinking model. Strong at coding, analysis, huge context window.",
-    "strengths": "Thinking model, coding, huge context"
+    "strengths": "Thinking model, coding, huge context",
+    "trackedSince": "2026-02-23"
+  },
+  {
+    "id": "google/gemini-3.5-flash",
+    "name": "Gemini 3.5 Flash",
+    "provider": "Google",
+    "family": "Gemini 3",
+    "released": "2026-06",
+    "contextK": 1048,
+    "inputPrice": 1.5,
+    "outputPrice": 9.0,
+    "openSource": false,
+    "reasoning": true,
+    "multimodal": true,
+    "coding": 88,
+    "reasoning_score": 89,
+    "speed": 95,
+    "description": "Google's streaming-first Gemini 3.5 workhorse. Powers the Live API including real-time translation.",
+    "strengths": "Streaming latency, native audio and video, 1M context",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-06-10#ph-gemini-live-translate"
   },
   {
     "id": "meta-llama/llama-4-maverick",
@@ -180,7 +249,8 @@
     "reasoning_score": 83,
     "speed": 55,
     "description": "Strong open-source contender. 1M context, multimodal, competitive with proprietary.",
-    "strengths": "Strong open-source, 1M context, multimodal"
+    "strengths": "Strong open-source, 1M context, multimodal",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "meta-llama/llama-4-scout",
@@ -198,7 +268,8 @@
     "reasoning_score": 80,
     "speed": 45,
     "description": "10M token context. MoE architecture, self-hostable, multimodal.",
-    "strengths": "10M context, MoE architecture, self-hostable"
+    "strengths": "10M context, MoE architecture, self-hostable",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "mistralai/mistral-large-2512",
@@ -216,7 +287,8 @@
     "reasoning_score": 80,
     "speed": 60,
     "description": "European flagship. Excellent multilingual, 256K context, strong at code.",
-    "strengths": "Multilingual, code, reasoning, larger context"
+    "strengths": "Multilingual, code, reasoning, larger context",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "mistralai/mistral-small-3.1-24b-instruct",
@@ -234,7 +306,28 @@
     "reasoning_score": 68,
     "speed": 90,
     "description": "Very cheap and fast. Punches above its weight for simple to medium tasks.",
-    "strengths": "Very cheap, strong for its size"
+    "strengths": "Very cheap, strong for its size",
+    "trackedSince": "2026-02-23"
+  },
+  {
+    "id": "moonshotai/kimi-k2.6",
+    "name": "Kimi K2.6",
+    "provider": "Moonshot AI",
+    "family": "Kimi",
+    "released": "2026-04",
+    "contextK": 262,
+    "inputPrice": 0.68,
+    "outputPrice": 3.41,
+    "openSource": false,
+    "reasoning": true,
+    "multimodal": true,
+    "coding": 89,
+    "reasoning_score": 87,
+    "speed": 65,
+    "description": "Moonshot's agent-focused update to K2. Strong tool use at commodity pricing.",
+    "strengths": "Agentic tool use, long context, price",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-04-21#ph-kimi-k26"
   },
   {
     "id": "moonshotai/kimi-k2",
@@ -252,7 +345,8 @@
     "reasoning_score": 82,
     "speed": 50,
     "description": "Long-context reasoning model. Competitive pricing and strong performance.",
-    "strengths": "Long-context reasoning, competitive pricing"
+    "strengths": "Long-context reasoning, competitive pricing",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "openai/gpt-4.1",
@@ -270,7 +364,8 @@
     "reasoning_score": 86,
     "speed": 72,
     "description": "Million-token context, strong at coding and instruction following.",
-    "strengths": "Million-token context, coding, instruction following"
+    "strengths": "Million-token context, coding, instruction following",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "openai/gpt-4o",
@@ -288,7 +383,8 @@
     "reasoning_score": 85,
     "speed": 75,
     "description": "Multimodal workhorse from OpenAI. Good all-rounder for text, vision, and audio.",
-    "strengths": "Multimodal, general purpose"
+    "strengths": "Multimodal, general purpose",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "openai/gpt-5",
@@ -306,7 +402,8 @@
     "reasoning_score": 94,
     "speed": 55,
     "description": "Flagship OpenAI model. 400K context, strong across all tasks.",
-    "strengths": "Massive context, strong all-rounder"
+    "strengths": "Massive context, strong all-rounder",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "openai/gpt-5-mini",
@@ -324,7 +421,8 @@
     "reasoning_score": 80,
     "speed": 80,
     "description": "Budget GPT-5 class model with large context window.",
-    "strengths": "Budget GPT-5 class, large context"
+    "strengths": "Budget GPT-5 class, large context",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "openai/gpt-5-nano",
@@ -342,7 +440,28 @@
     "reasoning_score": 65,
     "speed": 96,
     "description": "Cheapest frontier model. On-device capable, great for high-volume simple tasks.",
-    "strengths": "Cheapest frontier model, on-device capable"
+    "strengths": "Cheapest frontier model, on-device capable",
+    "trackedSince": "2026-02-23"
+  },
+  {
+    "id": "openai/gpt-5.5",
+    "name": "GPT-5.5",
+    "provider": "OpenAI",
+    "family": "GPT-5",
+    "released": "2026-05",
+    "contextK": 1050,
+    "inputPrice": 5.0,
+    "outputPrice": 30.0,
+    "openSource": false,
+    "reasoning": true,
+    "multimodal": true,
+    "coding": 96,
+    "reasoning_score": 96,
+    "speed": 60,
+    "description": "OpenAI's flagship successor to GPT-5. Instant-mode routing picks effort per request.",
+    "strengths": "Strong all-rounder, instant routing, broad tooling",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-05-06#ph-gpt-55-instant"
   },
   {
     "id": "openai/o3",
@@ -360,7 +479,8 @@
     "reasoning_score": 96,
     "speed": 25,
     "description": "Deep reasoning model. Excels at maths, science, coding, and logic problems.",
-    "strengths": "Reasoning, maths, science, coding"
+    "strengths": "Reasoning, maths, science, coding",
+    "trackedSince": "2026-02-23"
   },
   {
     "id": "openai/o3-mini",
@@ -378,6 +498,47 @@
     "reasoning_score": 88,
     "speed": 55,
     "description": "Budget reasoning model. Good value for tasks that need structured thinking.",
-    "strengths": "Budget reasoning model, structured thinking"
+    "strengths": "Budget reasoning model, structured thinking",
+    "trackedSince": "2026-02-23"
+  },
+  {
+    "id": "z-ai/glm-5",
+    "name": "GLM-5",
+    "provider": "Z.ai",
+    "family": "GLM",
+    "released": "2026-04",
+    "contextK": 202,
+    "inputPrice": 0,
+    "outputPrice": 0,
+    "openSource": true,
+    "reasoning": true,
+    "multimodal": false,
+    "coding": 87,
+    "reasoning_score": 85,
+    "speed": 70,
+    "description": "Z.ai's open-weights flagship. Self-hostable frontier-adjacent capability.",
+    "strengths": "Open weights, strong reasoning per dollar, self-hosting",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-04-02#ph-glm-5v-turbo"
+  },
+  {
+    "id": "x-ai/grok-4.3",
+    "name": "Grok 4.3",
+    "provider": "xAI",
+    "family": "Grok",
+    "released": "2026-05",
+    "contextK": 1000,
+    "inputPrice": 1.25,
+    "outputPrice": 2.5,
+    "openSource": false,
+    "reasoning": true,
+    "multimodal": true,
+    "coding": 91,
+    "reasoning_score": 92,
+    "speed": 80,
+    "description": "xAI's fast frontier model. Aggressive pricing for the capability tier.",
+    "strengths": "Speed at frontier level, low price, 1M context",
+    "trackedSince": "2026-06-10",
+    "radarRef": "2026-05-02#ph-grok-43"
   }
 ]


### PR DESCRIPTION
Per docs/designs/tools-page-showroom.md (B3, B4, E2, E5 + eng E1/E4/E5/E6).

Catalogue: 21 -> 28 models (Fable 5, Opus 4.7, GPT-5.5, Grok 4.3, Gemini 3.5 Flash, Kimi K2.6, GLM-5), scores calibrated against the Artificial Analysis index. TRACKED_IDS is gone - models.json IS the roster; new models enter only via Job 2's reviewed proposal PRs. 29 pytest cases incl. the Job 1 regression suite; validator + pytest now run in PR CI.

Build 810 pages green, validator clean, visually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)