### PR TITLE
Tools showroom: provenance strip + featured rotation + data-age (plan PR 3/5)

### DIFF
--- a/src/components/ProvenanceStrip.astro
+++ b/src/components/ProvenanceStrip.astro
@@ -1,0 +1,128 @@
+---
+// Provenance strip (plan B6+E4 merged per D9/5A, hardened per F1/F4/F8/F9).
+//
+// Collapsed: ONE mono line between the page intro and the Featured rule,
+// reading as a status line. Native <details> = tap/keyboard parity for free.
+// Staleness register (F4): <26h green dot, 26h-7d amber, >7d red — the
+// machinery being dead must LOOK dead. Absolute UTC timestamps render
+// server-side (crawlers/no-JS keep the proof); a tiny script upgrades the
+// summary time to a relative age client-side (width reserved, F8).
+import botsManifest from '../data/pipeline/bots.json';
+
+interface Run {
+  bot: string;
+  timestamp: string;
+  status: string;
+  items_published?: number;
+}
+
+// Whole-file guard (F9): an unparseable runs.json renders the no-data form;
+// the build never fails on it.
+let runs: Run[] = [];
+try {
+  runs = (await import('../data/pipeline/runs.json')).default as Run[];
+  if (!Array.isArray(runs)) runs = [];
+} catch {
+  runs = [];
+}
+
+const SECTION_LINKS: Record<string, string> = {
+  news_bot: '/news-and-updates',
+  thoughts_bot: '/thoughts',
+  radar_bot: '/radar',
+  tool_bot: '/tools',
+  prompt_bot: '/prompts',
+  model_bot: '/lab/model-comparison',
+  horizon_bot: '/horizon',
+};
+
+const now = Date.now();
+const weekAgo = now - 7 * 86400_000;
+
+const bots = (botsManifest as { id: string; name: string }[]).map((b) => {
+  const mine = runs.filter((r) => r.bot === b.id);
+  const lastOk = mine.filter((r) => r.status === 'success').at(-1);
+  const weekCount = mine
+    .filter((r) => new Date(r.timestamp).getTime() >= weekAgo)
+    .reduce((s, r) => s + (r.items_published || 0), 0);
+  const ageMs = lastOk ? now - new Date(lastOk.timestamp).getTime() : Infinity;
+  const dot =
+    ageMs < 26 * 3600_000 ? 'bg-neon-green' :
+    ageMs < 7 * 86400_000 ? 'bg-neon-amber' : 'bg-neon-red';
+  return {
+    ...b,
+    href: SECTION_LINKS[b.id] || '/pipeline',
+    lastOk: lastOk?.timestamp ?? null,
+    weekCount,
+    dot,
+  };
+});
+
+const newest = bots.filter((b) => b.lastOk).sort((a, b) => b.lastOk!.localeCompare(a.lastOk!))[0];
+const weekTotal = bots.reduce((s, b) => s + b.weekCount, 0);
+const fmtAbs = (iso: string) => iso.slice(0, 16).replace('T', ' ') + 'Z';
+const overallDot = newest ? newest.dot : 'bg-neon-red';
+---
+
+<details class="mb-8 font-mono text-xs text-text-muted group/strip">
+  <summary class="cursor-pointer select-none list-none flex items-center gap-2 min-h-11 [&::-webkit-details-marker]:hidden">
+    {newest ? (
+      <>
+        <span class={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${overallDot} motion-safe:animate-pulse`}></span>
+        <span class="truncate">
+          fed by the pipeline &middot; last output
+          <time
+            datetime={newest.lastOk}
+            data-age-ts={newest.lastOk}
+            title={fmtAbs(newest.lastOk!)}
+            class="inline-block min-w-[11ch] text-text-primary"
+          > {fmtAbs(newest.lastOk!)}</time>
+          &middot; {weekTotal} outputs this week
+        </span>
+        <span class="text-text-muted/50 shrink-0 group-open/strip:rotate-90 transition-transform">▸</span>
+        <span class="text-text-muted/50 shrink-0">detail</span>
+      </>
+    ) : (
+      <>
+        <span class="inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-neon-red"></span>
+        <span>pipeline data unavailable &middot; see <a href="/pipeline" class="text-neon-cyan hover:underline">/pipeline</a></span>
+      </>
+    )}
+  </summary>
+  {newest && (
+    <div class="mt-3 ml-3.5 grid gap-1.5">
+      {bots.map((b) => (
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${b.dot}`}></span>
+          <a href={b.href} class="text-neon-cyan hover:underline">{b.name}</a>
+          {b.lastOk ? (
+            <time datetime={b.lastOk} title={fmtAbs(b.lastOk)} class="text-text-muted/70">{fmtAbs(b.lastOk)}</time>
+          ) : (
+            <span class="text-text-muted/50">no data</span>
+          )}
+          <span class="text-text-muted/50">&middot; {b.weekCount} this week</span>
+        </div>
+      ))}
+      <div class="mt-1">
+        <a href="/pipeline" class="text-neon-cyan hover:underline">full run history &rarr;</a>
+      </div>
+    </div>
+  )}
+</details>
+
+<script>
+  // Upgrade the summary timestamp to a relative age (F8): absolute stays in
+  // the title attr + datetime; width reserved via min-w so no layout shift.
+  const rel = (iso: string) => {
+    const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+    if (s < 90) return 'just now';
+    if (s < 5400) return `${Math.round(s / 60)}m ago`;
+    if (s < 129600) return `${Math.round(s / 3600)}h ago`;
+    return `${Math.round(s / 86400)}d ago`;
+  };
+  document.querySelectorAll<HTMLElement>('[data-age-ts]').forEach((el) => {
+    const iso = el.dataset.ageTs;
+    if (!iso || isNaN(new Date(iso).getTime())) return; // NaN guard: keep absolute
+    el.textContent = ' ' + rel(iso);
+  });
+</script>

--- a/src/components/lab/ToolShowcase.tsx
+++ b/src/components/lab/ToolShowcase.tsx
@@ -9,6 +9,7 @@ interface Tool {
   icon: string;
   category: string;
   addedDate: string;
+  dataSource?: string;
 }
 
 const categories = [
@@ -68,7 +69,7 @@ function isNew(addedDate: string): boolean {
   return diffDays <= 30;
 }
 
-export default function ToolShowcase({ tools }: { tools: Tool[] }) {
+export default function ToolShowcase({ tools, modelDataStamp }: { tools: Tool[]; modelDataStamp?: string | null }) {
   const [active, setActive] = useState('all');
 
   const filtered = active === 'all' ? tools : tools.filter((t) => t.category === active);
@@ -143,10 +144,19 @@ export default function ToolShowcase({ tools }: { tools: Tool[] }) {
                       <p class="text-sm text-text-muted mt-1.5 leading-relaxed">
                         {tool.description}
                       </p>
-                      {/* Quick stat — desktop hover reveal */}
-                      <p class={`font-mono text-xs ${colors.text} mt-2 opacity-50 group-hover:opacity-100 transition-opacity hidden md:block`}>
-                        ▸ {tool.stat}
-                      </p>
+                      {tool.dataSource === 'models.json' && modelDataStamp ? (
+                        /* Data-age footer (E1/F3): replaces the hover stat on
+                           data-driven tools, ALWAYS visible — freshness proof
+                           that only appears on hover proves nothing. */
+                        <p class={`font-mono text-xs ${colors.text} mt-2`}>
+                          ▸ model data {modelDataStamp}
+                        </p>
+                      ) : (
+                        /* Quick stat — desktop hover reveal */
+                        <p class={`font-mono text-xs ${colors.text} mt-2 opacity-50 group-hover:opacity-100 transition-opacity hidden md:block`}>
+                          ▸ {tool.stat}
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/data/tools-manifest.json
+++ b/src/data/tools-manifest.json
@@ -5,10 +5,10 @@
     "description": "Chat with any AI model via OpenRouter. Side-by-side comparison, streaming, cost tracking.",
     "stat": "21 models, live cost tracking",
     "href": "/lab/chat-playground",
-    "icon": "◈",
+    "icon": "\u25c8",
     "category": "models",
     "addedDate": "2026-02-01",
-    "featured": true
+    "dataSource": "models.json"
   },
   {
     "id": "prompt-workbench",
@@ -16,7 +16,7 @@
     "description": "Full prompt IDE. System/user/assistant prefill, variables, 8 templates, save/load, multi-format export.",
     "stat": "8 templates, localStorage persistence",
     "href": "/lab/prompt-workbench",
-    "icon": "⚙",
+    "icon": "\u2699",
     "category": "prompts",
     "addedDate": "2026-02-01"
   },
@@ -26,9 +26,10 @@
     "description": "Visual map of the AI model landscape. Timeline, capability bars, pricing calculator.",
     "stat": "Card, timeline & pricing views",
     "href": "/lab/model-explorer",
-    "icon": "◉",
+    "icon": "\u25c9",
     "category": "models",
-    "addedDate": "2026-02-01"
+    "addedDate": "2026-02-01",
+    "dataSource": "models.json"
   },
   {
     "id": "model-comparison",
@@ -36,9 +37,10 @@
     "description": "Sortable table of AI models with capability scores, pricing, and context windows.",
     "stat": "21 models, coding/reasoning/speed bars",
     "href": "/lab/model-comparison",
-    "icon": "⊞",
+    "icon": "\u229e",
     "category": "models",
-    "addedDate": "2026-02-01"
+    "addedDate": "2026-02-01",
+    "dataSource": "models.json"
   },
   {
     "id": "token-cost",
@@ -48,7 +50,8 @@
     "href": "/lab/token-cost",
     "icon": "$",
     "category": "cost",
-    "addedDate": "2026-02-01"
+    "addedDate": "2026-02-01",
+    "dataSource": "models.json"
   },
   {
     "id": "prompt-diff",
@@ -56,7 +59,7 @@
     "description": "Compare two prompt versions with word-level diff, token delta, and cost difference.",
     "stat": "LCS diff + load saved prompts",
     "href": "/lab/prompt-diff",
-    "icon": "~Δ",
+    "icon": "~\u0394",
     "category": "prompts",
     "addedDate": "2026-02-01"
   },

--- a/src/lib/feature-rotation.ts
+++ b/src/lib/feature-rotation.ts
@@ -1,0 +1,32 @@
+// Featured-spotlight rotation (plan B5 / D14).
+//
+//   manifest ──▶ any tool with featured: true? ──▶ pin it (editorial override)
+//        │                    no
+//        ▼
+//   ISO week number mod tool count ──▶ deterministic weekly pick, no state
+//
+// Pure function of (tools, date) so it is trivially testable and the
+// spotlight changes Mondays via the daily bot-commit deploys.
+
+export interface RotatableTool {
+  id: string;
+  featured?: boolean;
+}
+
+// ISO-8601 week number (Monday-based, week 1 contains the first Thursday).
+export function isoWeek(d: Date): number {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+export function pickFeatured<T extends RotatableTool>(tools: T[], now: Date): T | null {
+  if (!tools.length) return null; // mod-0 guard: no spotlight over no tools
+  const pinned = tools.find((t) => t.featured === true);
+  if (pinned) return pinned;
+  // year*53+week so the pick still advances across year boundaries
+  const n = now.getUTCFullYear() * 53 + isoWeek(now);
+  return tools[n % tools.length];
+}

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,9 +1,12 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ToolShowcase from '../../components/lab/ToolShowcase';
+import ProvenanceStrip from '../../components/ProvenanceStrip.astro';
 import { getCollection } from 'astro:content';
 import { tagDotClass } from '../../utils/tagColor';
 import toolsManifest from '../../data/tools-manifest.json';
+import { pickFeatured } from '../../lib/feature-rotation';
+import runsData from '../../data/pipeline/runs.json';
 
 const all = (await getCollection('tools'))
   .filter((e) => !e.data.draft)
@@ -20,8 +23,16 @@ const filterTags = [...tagCounts.entries()]
 
 const fmtDate = (d: Date) => d.toISOString().slice(0, 10);
 
-// Pick featured tool: first tool with "featured: true" in manifest, or fallback to first tool
-const featured = toolsManifest.find((t: any) => t.featured) || toolsManifest[0];
+// Featured spotlight (B5/D14): a featured:true manifest entry pins the
+// spotlight (editorial override); otherwise it rotates weekly by ISO week.
+const featured = pickFeatured(toolsManifest as any[], new Date()) || toolsManifest[0];
+
+// Data-age stamp for data-driven lab tools (E1/F3): model_bot's latest
+// successful prices run. Absolute UTC, rendered as text (F8).
+const modelRuns = (runsData as any[]).filter((r) => r.bot === 'model_bot' && r.status === 'success');
+const modelDataStamp: string | null = modelRuns.length
+  ? modelRuns[modelRuns.length - 1].timestamp.slice(0, 16).replace('T', ' ') + 'Z'
+  : null;
 
 const categoryColors: Record<string, { text: string; bg: string; border: string; glowVar: string; hex: string }> = {
   prompts: { text: 'text-neon-amber', bg: 'bg-neon-amber/10', border: 'border-neon-amber/30', glowVar: 'rgba(212, 165, 74, 0.12)', hex: '#d4a54a' },
@@ -41,10 +52,13 @@ const featuredColor = categoryColors[featured.category] || categoryColors.models
       <p class="text-text-muted mt-2">Interactive tools built for people who work with AI. All client-side, nothing leaves your browser.</p>
     </header>
 
-    <!-- Featured tool spotlight -->
+    <ProvenanceStrip />
+
+    <!-- Featured tool spotlight: rotates weekly, featured:true pins (B5/D14) -->
     <div class="mb-10">
       <div class="flex items-center gap-2 mb-4">
-        <span class="font-mono text-xs text-text-muted tracking-wider uppercase">Featured</span>
+        <span class="font-mono text-xs text-text-muted tracking-wider uppercase">Featured this week</span>
+        <span class="font-mono text-xs text-text-muted/50">rotates weekly &middot; pinned picks override</span>
         <div class="flex-1 h-px bg-surface-light/50"></div>
       </div>
       <a
@@ -83,7 +97,7 @@ const featuredColor = categoryColors[featured.category] || categoryColors.models
         <span class="font-mono text-xs text-text-muted/50">{toolsManifest.length}</span>
         <div class="flex-1 h-px bg-surface-light/50"></div>
       </div>
-      <ToolShowcase client:load tools={toolsManifest} />
+      <ToolShowcase client:load tools={toolsManifest} modelDataStamp={modelDataStamp} />
     </div>
 
     <!-- Tool write-ups -->


### PR DESCRIPTION
Per docs/designs/tools-page-showroom.md (B5, B6, E1, E4 merged per D9/5A; design spec F1/F3/F4/F8/F9/F11).

The core showroom move: /tools now proves it is alive. One-line status strip with a fresh/aging/stale colour register, weekly rotating spotlight with editorial pin override, and always-visible model-data stamps on the four data-driven lab tools.

Build 810 pages green, validator clean, visually verified (collapsed + expanded + rotation confirmed live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)