### PR TITLE
Tool bot: weekly link verification, honest decay (plan PR 4/5)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,5 +29,5 @@ jobs:
           python-version: '3.12'
       - name: Bot unit tests
         run: |
-          pip install -q pytest httpx python-dotenv
+          pip install -q pytest httpx python-dotenv feedparser anthropic
           python -m pytest bot/tests/ -q

--- a/bot/tests/test_verify.py
+++ b/bot/tests/test_verify.py
@@ -1,0 +1,137 @@
+"""Link-verification tests (B7/E3 per D6/D12): the dead-link classifier is
+the function that can vandalise the public catalogue, so it gets the
+hostile-QA table. The 2am-Friday case: marktechpost 403s the bot for three
+straight weeks — the write-up must NOT archive.
+"""
+import httpx
+import pytest
+
+import tool_of_the_week as bot
+
+
+# ---- classifier ------------------------------------------------------------
+
+@pytest.mark.parametrize("code,verdict", [
+    (200, "ok"), (301, "ok"), (308, "ok"),
+    (404, "dead"), (410, "dead"),
+    (403, "unverifiable"),   # bot-blocking is NOT death
+    (429, "unverifiable"),   # rate limiting is NOT death
+    (500, "unverifiable"), (503, "unverifiable"),
+    (None, "unverifiable"),
+])
+def test_classify_status_codes(code, verdict):
+    assert bot.classify_status(code) == verdict
+
+
+def test_classify_dns_failure_is_dead():
+    exc = httpx.ConnectError("[Errno -2] Name or service not known")
+    assert bot.classify_status(None, exc) == "dead"
+
+
+def test_classify_connection_refused_is_dead():
+    exc = httpx.ConnectError("All connection attempts failed: connection refused")
+    assert bot.classify_status(None, exc) == "dead"
+
+
+def test_classify_timeout_is_unverifiable():
+    assert bot.classify_status(None, httpx.ReadTimeout("timed out")) == "unverifiable"
+
+
+def test_classify_tls_error_is_unverifiable():
+    assert bot.classify_status(None, httpx.ConnectError("TLS handshake failed")) == "unverifiable"
+
+
+# ---- streak logic -----------------------------------------------------------
+
+def test_streak_archives_after_three_consecutive_dead():
+    h = {}
+    for i in range(1, 4):
+        h, archive = bot.update_streak(h, "x.md", "dead")
+        assert h["x.md"]["streak"] == i
+        assert archive is (i >= bot.ARCHIVE_AFTER)
+
+
+def test_ok_resets_streak():
+    h, _ = bot.update_streak({}, "x.md", "dead")
+    h, _ = bot.update_streak(h, "x.md", "dead")
+    h, archive = bot.update_streak(h, "x.md", "ok")
+    assert h["x.md"]["streak"] == 0
+    assert archive is False
+    h, archive = bot.update_streak(h, "x.md", "dead")
+    assert h["x.md"]["streak"] == 1
+    assert archive is False
+
+
+def test_unverifiable_never_archives_and_preserves_streak():
+    """The marktechpost-403-for-a-month case: streak frozen, no archive."""
+    h, _ = bot.update_streak({}, "x.md", "dead")
+    h, _ = bot.update_streak(h, "x.md", "dead")
+    for _ in range(10):
+        h, archive = bot.update_streak(h, "x.md", "unverifiable")
+        assert archive is False
+    assert h["x.md"]["streak"] == 2  # untouched, not evidence either way
+
+
+# ---- frontmatter stamping ----------------------------------------------------
+
+FRONT = """---
+title: "Example"
+description: "x"
+date: 2026-06-07
+url: "https://example.com/article"
+status: experimental
+tags: [a]
+draft: false
+---
+
+Body.
+"""
+
+
+def test_stamp_ok_inserts_last_verified(tmp_path):
+    f = tmp_path / "t.md"
+    f.write_text(FRONT)
+    assert bot.stamp_file(f, "ok", False, "2026-06-10") is True
+    txt = f.read_text()
+    assert "last_verified: 2026-06-10" in txt
+    assert "status: experimental" in txt
+
+
+def test_stamp_ok_updates_existing_last_verified(tmp_path):
+    f = tmp_path / "t.md"
+    f.write_text(FRONT.replace("date: 2026-06-07", "date: 2026-06-07\nlast_verified: 2026-06-01"))
+    bot.stamp_file(f, "ok", False, "2026-06-10")
+    txt = f.read_text()
+    assert txt.count("last_verified") == 1
+    assert "last_verified: 2026-06-10" in txt
+
+
+def test_stamp_archive_flips_status(tmp_path):
+    f = tmp_path / "t.md"
+    f.write_text(FRONT)
+    assert bot.stamp_file(f, "dead", True, "2026-06-10") is True
+    assert "status: archived" in f.read_text()
+
+
+def test_stamp_noop_returns_false(tmp_path):
+    f = tmp_path / "t.md"
+    archived = FRONT.replace("status: experimental", "status: archived")
+    f.write_text(archived)
+    assert bot.stamp_file(f, "dead", True, "2026-06-10") is False
+
+
+# ---- corrupt history guard ----------------------------------------------------
+
+def test_corrupt_history_resets(tmp_path, monkeypatch):
+    bad = tmp_path / "tool_verify_history.json"
+    bad.write_text("{broken")
+    monkeypatch.setattr(bot, "VERIFY_HISTORY", bad)
+    assert bot.load_verify_history() == {}
+
+
+def test_urlless_writeups_are_skipped():
+    """The 3 site-authored write-ups have no url field — the verify loop's
+    frontmatter regex must not match them."""
+    for name in ("context-window-viz.md", "softcat-site.md", "token-cost-calculator.md"):
+        txt = (bot.CONTENT_DIR / name).read_text()
+        assert bot.FRONT_URL.search(txt) is None, name

--- a/bot/tool_of_the_week.py
+++ b/bot/tool_of_the_week.py
@@ -7,6 +7,7 @@ generates a markdown post in the house style, and commits it to the site repo.
 """
 
 import os
+import re
 import sys
 import json
 import hashlib
@@ -205,10 +206,186 @@ def ping_healthcheck(status="success"):
         print(f"Healthcheck ping failed: {e}")
 
 
+# --------------------------------------------------------------------------- #
+# Job 2: weekly link verification (B7/E3, hardened per D6/D12/E6.8)           #
+#                                                                              #
+#   write-up url ──▶ HTTP STATUS check only ──▶ verdict                       #
+#        │   (no content ever reaches an LLM)     │                           #
+#        │                                        ├─ ok ──▶ last_verified     #
+#   no url? skip                                  │         stamp             #
+#   (context-window-viz,                          ├─ unverifiable (403/429/   #
+#    softcat-site,                                │   timeout/5xx/SSL) ──▶    #
+#    token-cost-calculator)                       │   staged + /pipeline +    #
+#                                                 │   Discord, NEVER archives │
+#                                                 └─ definitive-dead (404/410/│
+#                                                     DNS/conn-refused) ──▶   │
+#                                                     streak; 3 consecutive   │
+#                                                     weeks ──▶ archived      │
+# --------------------------------------------------------------------------- #
+
+VERIFY_HISTORY = BOT_DIR / "tool_verify_history.json"
+UNVERIFIABLE_FILE = Path.home() / ".softcat-bot-staging" / "tool-verify-unverifiable.json"
+ARCHIVE_AFTER = 3  # consecutive definitive-dead weekly checks (D12)
+
+DEFINITIVE_DEAD_CODES = {404, 410}
+
+
+def classify_status(code: int | None, exc: Exception | None = None) -> str:
+    """Map an HTTP status (or transport error) to a verdict.
+
+    Returns 'ok' | 'dead' | 'unverifiable'. Archiving is reserved for
+    provable death; bot-blocking (403/429), timeouts, and server errors
+    are 'unverifiable' and only ever surfaced for manual review (D12/2A).
+    """
+    if exc is not None:
+        # DNS failure / connection refused are definitive-dead transport
+        # signals; everything else (timeout, TLS, protocol) is ambiguous.
+        import socket
+        if isinstance(exc, httpx.ConnectError):
+            cause = str(exc).lower()
+            if "name" in cause or "resolve" in cause or "refused" in cause or \
+               isinstance(exc.__cause__, (socket.gaierror, ConnectionRefusedError)):
+                return "dead"
+        return "unverifiable"
+    if code is None:
+        return "unverifiable"
+    if code in DEFINITIVE_DEAD_CODES:
+        return "dead"
+    if 200 <= code < 400:
+        return "ok"
+    return "unverifiable"
+
+
+def check_url(url: str) -> str:
+    """Status-code-only check. HEAD first, GET fallback (some hosts 405 HEAD).
+    Response bodies are never read into anything."""
+    try:
+        resp = httpx.head(url, timeout=15, follow_redirects=True)
+        if resp.status_code in (405, 501):
+            resp = httpx.get(url, timeout=15, follow_redirects=True)
+        return classify_status(resp.status_code)
+    except Exception as e:
+        return classify_status(None, e)
+
+
+def load_verify_history() -> dict:
+    """Corrupt history resets to empty with a logged warning (shadow guard)."""
+    if not VERIFY_HISTORY.exists():
+        return {}
+    try:
+        data = json.loads(VERIFY_HISTORY.read_text())
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, ValueError):
+        print(f"[tool_bot] WARNING: {VERIFY_HISTORY} corrupt, resetting streaks")
+        return {}
+
+
+def update_streak(history: dict, key: str, verdict: str) -> tuple[dict, bool]:
+    """Pure streak logic. Returns (history, should_archive).
+    'ok' resets the streak; 'unverifiable' leaves it untouched (a blocked
+    check is not evidence of death); 'dead' increments."""
+    entry = history.get(key, {"streak": 0})
+    if verdict == "ok":
+        entry["streak"] = 0
+    elif verdict == "dead":
+        entry["streak"] = entry.get("streak", 0) + 1
+    entry["last_verdict"] = verdict
+    history[key] = entry
+    return history, verdict == "dead" and entry["streak"] >= ARCHIVE_AFTER
+
+
+FRONT_URL = re.compile(r'^url:\s*"?([^"\n]+)"?\s*$', re.M)
+FRONT_STATUS = re.compile(r"^status:\s*(\w+)\s*$", re.M)
+FRONT_VERIFIED = re.compile(r"^last_verified:\s*\S+\s*$", re.M)
+
+
+def stamp_file(path: Path, verdict: str, archive: bool, today: str) -> bool:
+    """Apply last_verified stamp / archived flip to a write-up's frontmatter.
+    Returns True when the file changed. Data-only edits, direct-commit path."""
+    txt = path.read_text()
+    new = txt
+    if verdict == "ok":
+        if FRONT_VERIFIED.search(new):
+            new = FRONT_VERIFIED.sub(f"last_verified: {today}", new)
+        else:
+            new = re.sub(r"(^date:.*$)", rf"\1\nlast_verified: {today}", new, count=1, flags=re.M)
+    if archive and FRONT_STATUS.search(new):
+        current = FRONT_STATUS.search(new).group(1)
+        if current != "archived":
+            new = FRONT_STATUS.sub("status: archived", new, count=1)
+    if new != txt:
+        path.write_text(new)
+        return True
+    return False
+
+
+def post_unverifiable_to_discord(items: list[dict]):
+    webhook = os.environ.get("DISCORD_WEBHOOK_TOOL_OF_WEEK")
+    if not webhook or not items:
+        return
+    lines = [f"**Tool bot:** {len(items)} link(s) unverifiable this week:"]
+    lines += [f"- {i['file']}: {i['url']}" for i in items[:10]]
+    try:
+        httpx.post(webhook, json={"content": "\n".join(lines),
+                                  "username": "SOFT CAT Tool of the Week"}, timeout=15)
+    except Exception as e:
+        print(f"[tool_bot] Discord post failed: {e}")
+
+
+def run_verify_job(t0: float):
+    """Job 2 entry point: weekly link checks across all write-ups."""
+    today = date.today().isoformat()
+    history = load_verify_history()
+    changed_files: list[str] = []
+    unverifiable: list[dict] = []
+    checked = archived = 0
+
+    for path in sorted(CONTENT_DIR.glob("*.md")):
+        m = FRONT_URL.search(path.read_text())
+        if not m:
+            continue  # url-less write-ups are skipped, no stamp (E6.8)
+        url = m.group(1).strip()
+        verdict = check_url(url)
+        checked += 1
+        history, should_archive = update_streak(history, path.name, verdict)
+        if verdict == "unverifiable":
+            unverifiable.append({"file": path.name, "url": url})
+            print(f"  unverifiable: {path.name}")
+            continue
+        if stamp_file(path, verdict, should_archive, today):
+            changed_files.append(f"src/content/tools/{path.name}")
+        if should_archive:
+            archived += 1
+            print(f"  ARCHIVED (streak {ARCHIVE_AFTER}): {path.name}")
+
+    VERIFY_HISTORY.write_text(json.dumps(history, indent=2) + "\n")
+
+    if unverifiable:
+        UNVERIFIABLE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        UNVERIFIABLE_FILE.write_text(json.dumps(
+            {"generated_at": today, "items": unverifiable}, indent=2) + "\n")
+        post_unverifiable_to_discord(unverifiable)
+
+    log_run("tool_bot", status="success", duration_s=_time.time() - t0,
+            items_found=checked, items_published=len(changed_files),
+            items_rejected=len(unverifiable), job="verify",
+            error_msg="" if not unverifiable else
+            f"{len(unverifiable)} unverifiable: " + ", ".join(i["file"] for i in unverifiable[:5]))
+
+    if changed_files:
+        git_safe.safe_commit_and_push(
+            changed_files + ["bot/tool_verify_history.json", "src/data/pipeline/runs.json"],
+            f"bot: verify write-up links ({today}, {archived} archived)")
+    print(f"[tool_bot] verify: {checked} checked, {len(changed_files)} stamped, "
+          f"{archived} archived, {len(unverifiable)} unverifiable")
+
+
 def main():
     print(f"[{datetime.now().isoformat()}] Tool of the Week bot starting")
     t0 = _time.time()
 
+    # ---- Job 1: weekly write-up. Early "nothing to publish" outcomes no
+    # longer exit the process — the verify job below runs every week.
     try:
         history = load_history()
 
@@ -216,50 +393,54 @@ def main():
         entries = fetch_feed_entries()
         print(f"Found {len(entries)} entries across {len(FEEDS)} feeds")
 
-        if not entries:
-            print("No entries found. Exiting.")
+        filename = None
+        if entries:
+            print("Picking a tool and writing it up...")
+            filename = pick_and_write(entries, history)
+
+        if filename:
+            usage = getattr(pick_and_write, "_last_usage", None)
+            cost = None
+            in_tok = out_tok = 0
+            if usage:
+                cost = (usage.input_tokens * 3 + usage.output_tokens * 15) / 1_000_000
+                in_tok, out_tok = usage.input_tokens, usage.output_tokens
+
+            # Log BEFORE commit so the runs.json entry lands in the same commit
+            # as this bot's data changes, not the next bot's commit (issue #97).
             log_run("tool_bot", status="success", duration_s=_time.time() - t0,
-                    feeds_scanned=len(FEEDS), items_found=0, items_published=0)
-            ping_healthcheck()
-            sys.exit(0)
+                    feeds_scanned=len(FEEDS), items_found=len(entries), items_published=1,
+                    model="claude-sonnet-4-20250514", cost_usd=cost,
+                    input_tokens=in_tok, output_tokens=out_tok,
+                    output_files=[f"src/content/tools/{filename}"])
 
-        print("Picking a tool and writing it up...")
-        filename = pick_and_write(entries, history)
-
-        if not filename:
-            print("Nothing to publish. Exiting.")
+            print("Committing and pushing...")
+            git_commit_and_push(filename)
+        else:
+            print("Nothing to publish this week.")
             log_run("tool_bot", status="success", duration_s=_time.time() - t0,
                     feeds_scanned=len(FEEDS), items_found=len(entries), items_published=0)
-            ping_healthcheck()
-            sys.exit(0)
-
-        usage = getattr(pick_and_write, "_last_usage", None)
-        cost = None
-        in_tok = out_tok = 0
-        if usage:
-            cost = (usage.input_tokens * 3 + usage.output_tokens * 15) / 1_000_000
-            in_tok, out_tok = usage.input_tokens, usage.output_tokens
-
-        # Log BEFORE commit so the runs.json entry lands in the same commit
-        # as this bot's data changes, not the next bot's commit (issue #97).
-        log_run("tool_bot", status="success", duration_s=_time.time() - t0,
-                feeds_scanned=len(FEEDS), items_found=len(entries), items_published=1,
-                model="claude-sonnet-4-20250514", cost_usd=cost,
-                input_tokens=in_tok, output_tokens=out_tok,
-                output_files=[f"src/content/tools/{filename}"])
-
-        print("Committing and pushing...")
-        git_commit_and_push(filename)
-
-        print("Done.")
-        ping_healthcheck()
 
     except Exception as e:
-        print(f"Bot failed: {e}")
+        print(f"Bot failed (write-up job): {e}")
         log_run("tool_bot", status="error", duration_s=_time.time() - t0,
                 error_msg=str(e))
         ping_healthcheck("fail")
         sys.exit(1)
+
+    # ---- Job 2: link verification (loud but independent of Job 1)
+    try:
+        print("Verifying write-up links...")
+        run_verify_job(t0)
+    except Exception as e:
+        print(f"Bot failed (verify job): {e}")
+        log_run("tool_bot", status="error", duration_s=_time.time() - t0,
+                error_msg=str(e), job="verify")
+        ping_healthcheck("fail")
+        sys.exit(1)
+
+    print("Done.")
+    ping_healthcheck()
 
 
 if __name__ == "__main__":

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -39,6 +39,7 @@ const tools = defineCollection({
     title: z.string(),
     description: z.string(),
     date: z.coerce.date(),
+    last_verified: z.coerce.date().optional(),
     url: z.string().optional(),
     labUrl: z.string().optional(),
     status: z.enum(['active', 'experimental', 'archived']).default('experimental'),

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -167,15 +167,22 @@ const featuredColor = categoryColors[featured.category] || categoryColors.models
                     </h2>
                     <p class="text-sm text-text-muted mt-2 leading-relaxed">{entry.data.description}</p>
                   </div>
-                  <div class="shrink-0 flex items-center gap-3">
-                    <span class="font-mono text-xs text-text-muted">{fmtDate(entry.data.date)}</span>
-                    <span class={`px-2 py-0.5 rounded text-xs font-mono ${
-                      entry.data.status === 'active' ? 'bg-neon-green/10 text-neon-green' :
-                      entry.data.status === 'experimental' ? 'bg-neon-amber/10 text-neon-amber' :
-                      'bg-surface-light text-text-muted'
-                    }`}>
-                      {entry.data.status}
-                    </span>
+                  <div class="shrink-0 flex flex-col items-end gap-1">
+                    <div class="flex items-center gap-3">
+                      <span class="font-mono text-xs text-text-muted">{fmtDate(entry.data.date)}</span>
+                      <span class={`px-2 py-0.5 rounded text-xs font-mono ${
+                        entry.data.status === 'active' ? 'bg-neon-green/10 text-neon-green' :
+                        entry.data.status === 'experimental' ? 'bg-neon-amber/10 text-neon-amber' :
+                        'bg-surface-light text-text-muted'
+                      }`}>
+                        {entry.data.status}
+                      </span>
+                    </div>
+                    {entry.data.last_verified && (
+                      <span class="font-mono text-[10px] text-text-muted/60">
+                        link checked {fmtDate(entry.data.last_verified)}
+                      </span>
+                    )}
                   </div>
                 </div>
               </a>


### PR DESCRIPTION
Per docs/designs/tools-page-showroom.md (B7, E3 per D6/D12/E6.8).

Status badges become signal: links are checked weekly, write-ups archive only on provable death (3 consecutive definitive-dead weeks), bot-blocking can never archive a live page, and the stamp says exactly what the bot knows: 'link checked YYYY-MM-DD'.

52 pytest cases green, build 810 pages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)