### PR TITLE
Copy: manifest-derived bot count, sharper machinery story

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,3 +1,10 @@
+---
+// Bot count derives from the manifest so this copy can never go stale
+// (it said "Six bots" for a month after the seventh joined).
+import allBots from '../data/pipeline/bots.json';
+const words = ['Zero', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine'];
+const botCount = words[allBots.length] ?? String(allBots.length);
+---
 <section class="max-w-5xl mx-auto px-6 pt-24 pb-16 md:pt-32 md:pb-24">
   <div class="mb-8">
     <div class="font-mono text-sm text-text-muted mb-6 flex items-center gap-1">
@@ -20,10 +27,10 @@
     </p>
 
     <p class="text-base text-text-muted max-w-2xl leading-relaxed mt-4">
-      Six bots. Five RSS feeds. One pipeline. Almost everything you see was generated,
-      reviewed, and published by automated AI infrastructure. The Horizon Map is the
-      exception: a hand-curated living chart of where AI has been, where it is, and
-      where it's credibly going next. The site is the product. The content is the
+      {botCount} bots on timers write and publish this site. The careful bits arrive
+      as pull requests, and we merge the good ones. The Horizon Map stays
+      hand-curated: a living chart of where AI has been, where it is, and where
+      it's credibly going next. The site is the product. The content is the
       output. The real story is the machinery.
     </p>
   </div>

--- a/src/pages/horizon.astro
+++ b/src/pages/horizon.astro
@@ -789,8 +789,8 @@ function stanceAccent(stance: 'optimistic' | 'pragmatic' | 'sceptical'): 'green'
           Explore the machinery
         </h3>
         <p class="text-sm text-text-muted leading-relaxed">
-          The horizon map is built and maintained by the same six bots that run the rest of the site.
-          <a href="/pipeline" class="text-neon-cyan hover:underline">See how it works</a>.
+          The horizon map runs on the same pipeline as the rest of the site. The bots
+          propose, we decide. <a href="/pipeline" class="text-neon-cyan hover:underline">See how it works</a>.
         </p>
       </div>
     </div>

--- a/src/pages/pipeline.astro
+++ b/src/pages/pipeline.astro
@@ -70,7 +70,7 @@ function formatDate(dateStr: string): string {
 }
 ---
 
-<BaseLayout title="Pipeline" description="The machinery behind softcat.ai. Six bots, five feeds, one pipeline. See every run, every cost, every decision.">
+<BaseLayout title="Pipeline" description={`The machinery behind softcat.ai. ${allBots.length} bots, one pipeline, receipts for everything. Every run, every cost, every decision.`}>
   <div class="max-w-4xl mx-auto px-6 py-16">
     <header class="mb-8">
       <a href="/" class="font-mono text-sm text-text-muted hover:text-neon-cyan transition-colors mb-4 inline-block">&larr; home</a>


### PR DESCRIPTION
Fixes the stale 'Six bots' copy (seven since horizon_bot joined) in Hero, /pipeline meta, and /horizon. Hero count now derives from bots.json at build, so bot number eight updates the homepage by existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)