### PR TITLE
ci: bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Full history so the horizon page's Weekly Shift Log module can
           # use `git log` as a fallback when shifts.json is missing.
@@ -31,7 +31,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Clears the Node 20 deprecation warning seen in recent deploy runs and brings both workflows to current majors.

## Changes
- `actions/checkout` **v6 → v7** (deploy + validate)
- `actions/upload-pages-artifact` **v4 → v5** (deploy) — v5 bundles `upload-artifact@v7`, which runs natively on Node 24. That transitive `upload-artifact` is the actual source of the deprecation warning.

Already at latest major (left as-is): `setup-node@v6`, `deploy-pages@v5`, `setup-python@v6`.

The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env stays in place as a harmless safety net.

## Safety
- checkout v7's only behavioral change blocks fork-PR checkout for `pull_request_target`/`workflow_run` — neither workflow uses those triggers (deploy = `push`, validate = `pull_request`).
- This PR's own CI exercises the `validate.yml` bumps. `deploy.yml` only runs post-merge on push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)