### PR TITLE
Model roster: add MiniMax M2.7 (verified)

### DIFF
--- a/src/data/models.json
+++ b/src/data/models.json
@@ -740,5 +740,25 @@
     "strengths": "Speed at frontier level, low price, 1M context",
     "trackedSince": "2026-06-10",
     "radarRef": "2026-05-02#ph-grok-43"
+  },
+  {
+    "id": "minimax/minimax-m2.7",
+    "name": "MiniMax M2.7",
+    "provider": "Minimax",
+    "released": "2026-03",
+    "family": "MiniMax",
+    "reasoning": true,
+    "openSource": true,
+    "coding": 80,
+    "reasoning_score": 73,
+    "speed": 80,
+    "description": "Open-weight MoE (230B total / 10B active), self-improving successor to M2; 56.2% SWE-Pro, 205K context, text-only.",
+    "strengths": "Agentic coding and reasoning at low cost, open weights",
+    "contextK": 205,
+    "inputPrice": 0.25,
+    "outputPrice": 1.0,
+    "multimodal": false,
+    "trackedSince": "2026-06-22",
+    "radarRef": "2026-04-12#ph-minimax-m2-7"
   }
 ]


### PR DESCRIPTION
Adds **MiniMax M2.7** to `src/data/models.json` with verified metadata.

Replaces the placeholder row from #169 (now closed). The other three entries in #169 were hallucinated non-models and were dropped:
- `anthropic/claude-opus-4.7-fast` — 'Fast' is a speed flag, not a separate model
- `google/lyria-3-pro-preview` — music model, out of scope
- `openrouter/fusion` — a router feature, not a model

## MiniMax M2.7 — verified
| Field | Value | Source |
|---|---|---|
| Released | 2026-03-18 | MiniMax / NVIDIA |
| Architecture | MoE 230B total / 10B active | MiniMax docs |
| Context | 205K | OpenRouter |
| Price | $0.25 in / $1.00 out per 1M | OpenRouter |
| Open weights | yes | HuggingFace |
| Coding | 56.2% SWE-Pro | MiniMax |

Editorial scores (coding 80 / reasoning 73 / speed 80) set relative to the existing MiniMax M2 row — adjust if desired before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)