### PR TITLE
horizon: link Now-card evidence sources instead of a bare count

### DIFF
--- a/src/lib/horizon-evidence.ts
+++ b/src/lib/horizon-evidence.ts
@@ -1,0 +1,93 @@
+// Horizon evidence -> outbound link resolver.
+//
+// Every Now-lane card carries a structured `evidence[]` array
+// ({ type, ref, label }) but the page historically rendered only the COUNT
+// ("3 sources") and threw the refs away. This turns each evidence item into a
+// real link where a built page exists, and degrades to plain text otherwise so
+// we never ship a 404.
+//
+// Resolution rules, per ref type (mirrors scripts/validate-horizon-refs.mjs):
+//   radar    -> /radar/<date>, but ONLY if that date is inside the built
+//               window (radar/[date].astro builds the newest RADAR_VISIBLE_DAYS
+//               dates; older archive dates have no page).
+//   thought  -> /thoughts/<slug>
+//   news     -> /news-and-updates/<slug>
+//   paper    -> arXiv / DOI / URL if the ref looks like one, else plain text.
+//   external -> the ref itself (schema guarantees it is an http(s) URL).
+//
+// Fallback for thought/news: horizon_bot has historically emitted bare-date
+// refs ("2026-06-10") or untruncated slugs that do not match the truncated
+// content filename. When an exact slug match fails we take the leading date and
+// link it IF exactly one content file shares that date (ambiguous -> plain
+// text). This recovers most of those without ever guessing wrong.
+
+export type EvidenceType = 'radar' | 'news' | 'thought' | 'paper' | 'external';
+
+export interface Evidence {
+  type: EvidenceType;
+  ref: string;
+  label: string;
+}
+
+export interface ResolverIndex {
+  thoughtSlugs: Set<string>;
+  newsSlugs: Set<string>;
+  visibleRadarDates: Set<string>;
+}
+
+export interface EvidenceLink {
+  label: string;
+  type: EvidenceType;
+  href: string | null; // null => render as plain text, no link
+  external: boolean;
+}
+
+const LEADING_DATE = /^(\d{4}-\d{2}-\d{2})/;
+const URL_RE = /^https?:\/\/\S+$/;
+const ARXIV_RE = /^\d{4}\.\d{4,5}(v\d+)?$/;
+const DOI_RE = /^10\.\d{4,9}\/\S+$/;
+
+// Exact slug, else the unique content file sharing the ref's leading date.
+function resolveContentSlug(ref: string, slugs: Set<string>): string | null {
+  if (slugs.has(ref)) return ref;
+  const m = ref.match(LEADING_DATE);
+  if (!m) return null;
+  const date = m[1];
+  const matches = [...slugs].filter((s) => s.startsWith(date));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function paperUrl(ref: string): string | null {
+  if (URL_RE.test(ref)) return ref;
+  if (ARXIV_RE.test(ref)) return `https://arxiv.org/abs/${ref}`;
+  if (DOI_RE.test(ref)) return `https://doi.org/${ref}`;
+  return null;
+}
+
+export function resolveEvidence(ev: Evidence, idx: ResolverIndex): EvidenceLink {
+  const base = { label: ev.label, type: ev.type };
+  switch (ev.type) {
+    case 'external':
+      return { ...base, href: URL_RE.test(ev.ref) ? ev.ref : null, external: true };
+    case 'radar':
+      return {
+        ...base,
+        href: idx.visibleRadarDates.has(ev.ref) ? `/radar/${ev.ref}` : null,
+        external: false,
+      };
+    case 'thought': {
+      const slug = resolveContentSlug(ev.ref, idx.thoughtSlugs);
+      return { ...base, href: slug ? `/thoughts/${slug}` : null, external: false };
+    }
+    case 'news': {
+      const slug = resolveContentSlug(ev.ref, idx.newsSlugs);
+      return { ...base, href: slug ? `/news-and-updates/${slug}` : null, external: false };
+    }
+    case 'paper': {
+      const url = paperUrl(ev.ref);
+      return { ...base, href: url, external: url != null };
+    }
+    default:
+      return { ...base, href: null, external: false };
+  }
+}

--- a/src/pages/horizon.astro
+++ b/src/pages/horizon.astro
@@ -3,6 +3,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import HorizonFilter from '../components/HorizonFilter.tsx';
 import { getCollection } from 'astro:content';
 import shiftsData from '../data/horizon/shifts.json';
+import radarIndex from '../data/radar/index.json';
+import { RADAR_VISIBLE_DAYS } from '../utils/radar';
+import { resolveEvidence } from '../lib/horizon-evidence';
 
 // Load all five horizon lane collections.
 const pastEntries = await getCollection('horizonPast');
@@ -10,6 +13,18 @@ const nowEntries = await getCollection('horizonNow');
 const nextEntries = await getCollection('horizonNext');
 const debateEntries = await getCollection('horizonDebates');
 const scenarioEntries = await getCollection('horizonScenarios');
+
+// Build-time index so each card's evidence[] can resolve to a real link.
+// Slug sets come straight from the collections (every id is a built page);
+// radar only builds the newest RADAR_VISIBLE_DAYS dates, so older archive
+// dates resolve to plain text rather than a 404. See lib/horizon-evidence.ts.
+const thoughtEntries = await getCollection('thoughts');
+const newsEntries = await getCollection('news-and-updates');
+const evidenceIndex = {
+  thoughtSlugs: new Set(thoughtEntries.map((e) => e.id)),
+  newsSlugs: new Set(newsEntries.map((e) => e.id)),
+  visibleRadarDates: new Set(radarIndex.dates.slice(0, RADAR_VISIBLE_DAYS)),
+};
 
 // Sort Now by date descending so the most recent signal lands at the top.
 const sortedNow = [...nowEntries].sort((a, b) =>
@@ -367,12 +382,39 @@ function stanceAccent(stance: 'optimistic' | 'pragmatic' | 'sceptical'): 'green'
               </div>
             )}
 
-            <div class="flex items-center justify-between font-mono text-[11px] text-text-muted/70 pt-3 border-t border-surface-light/50">
-              <span>{formatDate(entry.data.date)}</span>
+            <div class="pt-3 border-t border-surface-light/50">
+              <div class="flex items-center justify-between font-mono text-[11px] text-text-muted/70">
+                <span>{formatDate(entry.data.date)}</span>
+                {entry.data.evidence && entry.data.evidence.length > 0 && (
+                  <span>
+                    {entry.data.evidence.length} {entry.data.evidence.length === 1 ? 'source' : 'sources'}
+                  </span>
+                )}
+              </div>
               {entry.data.evidence && entry.data.evidence.length > 0 && (
-                <span>
-                  {entry.data.evidence.length} {entry.data.evidence.length === 1 ? 'source' : 'sources'}
-                </span>
+                <ul class="mt-2.5 flex flex-col gap-1.5">
+                  {entry.data.evidence.map((ev) => {
+                    const link = resolveEvidence(ev, evidenceIndex);
+                    return (
+                      <li class="flex items-baseline gap-2 text-xs leading-snug">
+                        <span class="shrink-0 font-mono text-[9px] uppercase tracking-wider text-text-muted/60 w-12">
+                          {ev.type}
+                        </span>
+                        {link.href ? (
+                          <a
+                            href={link.href}
+                            class="text-neon-cyan hover:underline"
+                            {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                          >
+                            {ev.label}
+                          </a>
+                        ) : (
+                          <span class="text-text-muted">{ev.label}</span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
               )}
             </div>
           </article>


### PR DESCRIPTION
## What

Now-lane Horizon cards showed **"N sources"** as plain text and threw away the structured `evidence[]` array behind it. No proof, no link. This renders each evidence item as a labelled, linked source.

## How

New resolver `src/lib/horizon-evidence.ts` maps each `{type, ref, label}` to a real destination:

| type | destination |
|------|-------------|
| `radar` | `/radar/<date>` — only within the built `RADAR_VISIBLE_DAYS` window |
| `thought` | `/thoughts/<slug>` |
| `news` | `/news-and-updates/<slug>` |
| `paper` | arXiv / DOI / URL when recognisable |
| `external` | the URL (new tab) |

It mirrors `validate-horizon-refs.mjs` and **degrades to plain text — never a 404** — when a ref has no built page (e.g. radar archive dates older than the visible window).

A **date-prefix fallback** recovers `horizon_bot`'s historically broken refs: bare dates (`2026-06-10`) and untruncated slugs that don't match the truncated content filename. When exactly one content file shares the ref's leading date, it links; ambiguous → plain text.

## Verification

- `npm run build` green (828 pages).
- 83 / 101 evidence rows now render as links (32 thought, 26 radar, 25 news); the remaining 18 are old radar-archive dates with no built page, correctly shown as plain text.
- All 60 unique evidence links confirmed to resolve to a built `dist/.../index.html` — zero 404s.

## Note (separate follow-up, not in this PR)

The horizon ref validator is currently **red with 48 errors** — `horizon_bot` has been emitting bare-date / untruncated-slug evidence refs that don't resolve to content files. This PR's renderer papers over most of them via the fallback, but the underlying data and the bot that writes it should be fixed so the validator goes green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)