### PR TITLE
horizon: fix 48 dangling evidence refs + stop the bot emitting them

### DIFF
--- a/bot/horizon_bot.py
+++ b/bot/horizon_bot.py
@@ -203,6 +203,72 @@ def load_pending_proposals() -> list[dict]:
     return pending
 
 
+def _resolve_evidence_ref(
+    ev_type: str, ref: str, *,
+    radar_dates: set[str],
+    thought_index: dict[str, list[str]],
+    news_index: dict[str, list[str]],
+) -> str | None:
+    """Map a model-supplied evidence ref onto one that resolves to real content,
+    mirroring scripts/validate-horizon-refs.mjs and src/lib/horizon-evidence.ts.
+
+    Returns the corrected ref, or None if it cannot be resolved (caller drops
+    the item). *_index map a slug's leading date (YYYY-MM-DD) -> slugs.
+    """
+    if ev_type == "radar":
+        return ref if ref in radar_dates else None
+    if ev_type in ("thought", "news"):
+        index = thought_index if ev_type == "thought" else news_index
+        if any(ref in slugs for slugs in index.values()):
+            return ref                       # exact slug already valid
+        cands = index.get(ref[:10], [])      # fall back to the unique same-day slug
+        return cands[0] if len(cands) == 1 else None
+    return ref                               # paper / external: pass through
+
+
+def _sanitize_evidence(
+    proposal: dict,
+    radar_items: list[dict],
+    thoughts: list[dict],
+    news: list[dict],
+) -> dict:
+    """Rewrite/strip a proposal's evidence so every ref resolves to real content.
+
+    Defence-in-depth behind the prompt fix: the model is now shown the exact
+    `ref=` token to copy, but if it still abbreviates a slug to its date or
+    invents one, we resolve against the SAME context it was shown and drop
+    (logging) anything that points at nothing. Stops broken refs at the source
+    rather than relying on the renderer's graceful fallback.
+    """
+    radar_dates = {r.get("_radar_date") for r in radar_items}
+    thought_index: dict[str, list[str]] = {}
+    for t in thoughts:
+        thought_index.setdefault(t["slug"][:10], []).append(t["slug"])
+    news_index: dict[str, list[str]] = {}
+    for n in news:
+        news_index.setdefault(n["slug"][:10], []).append(n["slug"])
+
+    kept = []
+    for ev in proposal.get("evidence", []) or []:
+        ref = _resolve_evidence_ref(
+            ev.get("type", ""), ev.get("ref", ""),
+            radar_dates=radar_dates,
+            thought_index=thought_index,
+            news_index=news_index,
+        )
+        if ref is None:
+            print(f"[horizon_bot] dropped unresolvable evidence "
+                  f"{ev.get('type')}:{ev.get('ref')!r} on {proposal.get('id')}")
+            continue
+        kept.append({**ev, "ref": ref})
+    proposal["evidence"] = kept
+    if len(kept) < 2:
+        print(f"[horizon_bot] WARNING: {proposal.get('id')} has {len(kept)} "
+              f"resolvable evidence item(s) after sanitisation (two-source "
+              f"rule) — Valori should review before merge.")
+    return proposal
+
+
 def propose_now_entries(
     radar_items: list[dict],
     thoughts: list[dict],
@@ -222,16 +288,21 @@ def propose_now_entries(
         f"- {p['title']} [{', '.join(p['themes']) or 'no-themes'}]" for p in pending
     ) or "(none)"
 
+    # Every item leads with `ref=<stem>` so the model can copy the exact
+    # citeable id verbatim. Before this, the context showed only [date] + title
+    # and the model guessed the ref — abbreviating thought/news slugs to a bare
+    # date or inventing one, which shipped 48 dangling evidence refs (fixed
+    # 2026-06-23). Radar's ref IS its date; thoughts/news cite the full slug.
     radar_text = "\n".join(
-        f"- [{r.get('_radar_date')}] {r.get('name','?')}: {r.get('description','')[:200]}"
+        f"- ref={r.get('_radar_date')} | {r.get('name','?')}: {r.get('description','')[:200]}"
         for r in radar_items[:60]
     ) or "(none)"
     thoughts_text = "\n".join(
-        f"- [{t['date']}] {t['title']}: {t['summary'][:200]}"
+        f"- ref={t['slug']} | [{t['date']}] {t['title']}: {t['summary'][:200]}"
         for t in thoughts
     ) or "(none)"
     news_text = "\n".join(
-        f"- [{n['date']}] {n['title']}: {n['summary'][:200]}"
+        f"- ref={n['slug']} | [{n['date']}] {n['title']}: {n['summary'][:200]}"
         for n in news
     ) or "(none)"
     existing_text = "\n".join(f"- {t}" for t in existing_titles) or "(none yet)"
@@ -261,9 +332,11 @@ PATTERNS that deserve a Now entry.
    model architectures", "coding models crossing 70%" — DO NOT re-propose it
    with different wording. Wait for the existing PR to merge or be closed.
 4. Output AT MOST 3 proposals. It is valid (and often correct) to output zero.
-5. Each proposal must cite its evidence with the exact radar date or
-   thought/news slug from the context. The `ref` field is the filename stem
-   (e.g. "2026-04-09" for radar, "2026-04-08-slug" for thoughts/news).
+5. Each evidence item's `ref` MUST be copied VERBATIM from the `ref=` token of
+   the exact context item you are citing. Do NOT abbreviate a thought/news slug
+   to its date, and do NOT invent a slug. Only cite items shown in the context
+   above. (radar ref is a date like "2026-04-09"; thought/news ref is the full
+   slug like "2026-04-08-some-headline".)
 6. `themes` must be a subset of: {sorted(HORIZON_THEMES)}.
 7. `confidence` is one of: confirmed, emerging, contested, speculative. Default
    to "emerging" unless the pattern is demonstrably well-established (confirmed)
@@ -340,6 +413,7 @@ apologise, do not explain, just return the JSON.
         themes = p.get("themes", [])
         if not themes or any(t not in HORIZON_THEMES for t in themes):
             continue
+        _sanitize_evidence(p, radar_items, thoughts, news)
         clean.append(p)
     return clean, response.usage
 

--- a/bot/tests/test_horizon_evidence.py
+++ b/bot/tests/test_horizon_evidence.py
@@ -1,0 +1,68 @@
+"""Regression tests for horizon_bot evidence sanitisation.
+
+Pins the fix for the 48 dangling evidence refs (2026-06-23): the model used to
+abbreviate thought/news slugs to a bare date or invent them. _sanitize_evidence
+must rewrite a recoverable ref to its real slug and DROP anything that resolves
+to nothing, so a broken ref can never reach now.json again.
+"""
+import horizon_bot as bot
+
+RADAR = [{"_radar_date": "2026-06-22"}, {"_radar_date": "2026-06-21"}]
+THOUGHTS = [
+    {"slug": "2026-06-22-government-bans-are-free-marketing", "date": "2026-06-22"},
+    {"slug": "2026-06-10-real-time-streaming-arms-race", "date": "2026-06-10"},
+]
+NEWS = [
+    {"slug": "2026-06-22-ai-digest", "date": "2026-06-22"},
+    {"slug": "2026-06-21-ai-digest", "date": "2026-06-21"},
+]
+
+
+def sanitize(evidence):
+    p = {"id": "now-test", "evidence": evidence}
+    return bot._sanitize_evidence(p, RADAR, THOUGHTS, NEWS)["evidence"]
+
+
+def test_exact_slug_is_kept():
+    out = sanitize([{"type": "thought", "ref": "2026-06-10-real-time-streaming-arms-race", "label": "x"}])
+    assert out[0]["ref"] == "2026-06-10-real-time-streaming-arms-race"
+
+
+def test_bare_date_thought_is_rewritten_to_full_slug():
+    out = sanitize([{"type": "thought", "ref": "2026-06-10", "label": "x"}])
+    assert out[0]["ref"] == "2026-06-10-real-time-streaming-arms-race"
+
+
+def test_overlong_slug_is_rewritten_via_leading_date():
+    out = sanitize([{"type": "news", "ref": "2026-06-22-ai-digest-money-agents-and-grade-inflation", "label": "x"}])
+    assert out[0]["ref"] == "2026-06-22-ai-digest"
+
+
+def test_valid_radar_date_is_kept():
+    out = sanitize([{"type": "radar", "ref": "2026-06-21", "label": "x"}])
+    assert out[0]["ref"] == "2026-06-21"
+
+
+def test_unknown_radar_date_is_dropped():
+    out = sanitize([{"type": "radar", "ref": "2026-01-01", "label": "x"}])
+    assert out == []
+
+
+def test_unresolvable_thought_is_dropped():
+    out = sanitize([{"type": "thought", "ref": "2099-12-31", "label": "x"}])
+    assert out == []
+
+
+def test_ambiguous_date_is_dropped():
+    # Two thoughts share a date -> a bare-date ref is ambiguous, so dropped.
+    thoughts = [
+        {"slug": "2026-06-15-first", "date": "2026-06-15"},
+        {"slug": "2026-06-15-second", "date": "2026-06-15"},
+    ]
+    p = {"id": "now-test", "evidence": [{"type": "thought", "ref": "2026-06-15", "label": "x"}]}
+    assert bot._sanitize_evidence(p, RADAR, thoughts, NEWS)["evidence"] == []
+
+
+def test_label_is_preserved_on_rewrite():
+    out = sanitize([{"type": "thought", "ref": "2026-06-10", "label": "Streaming"}])
+    assert out[0]["label"] == "Streaming"

--- a/src/data/horizon/now.json
+++ b/src/data/horizon/now.json
@@ -244,12 +244,12 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-04-18",
+        "ref": "2026-04-18-debug-logs-just-became-the-most-valuable-training-data-in-te",
         "label": "Debug logs just became the most valuable training data in tech"
       },
       {
         "type": "thought",
-        "ref": "2026-04-22",
+        "ref": "2026-04-22-synthetic-data-generation-is-just-admitting-we-never-learned",
         "label": "Synthetic data generation is just admitting we never learned to collect the right data"
       },
       {
@@ -277,7 +277,7 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-04-27",
+        "ref": "2026-04-27-ai-agents-just-turned-economics-into-a-debugging-problem",
         "label": "AI agents just turned economics into a debugging problem"
       },
       {
@@ -287,7 +287,7 @@
       },
       {
         "type": "news",
-        "ref": "2026-04-26",
+        "ref": "2026-04-26-ai-digest",
         "label": "AI digest: Models get stronger, commerce gets weirder"
       }
     ],
@@ -309,17 +309,17 @@
     "evidence": [
       {
         "type": "news",
-        "ref": "2026-04-29",
+        "ref": "2026-04-29-ai-digest",
         "label": "Poolside's coding models reach 72.5% on SWE-bench"
       },
       {
         "type": "thought",
-        "ref": "2026-04-29-agentic-coding-models-just-made-software-engineering-a-spectator-sport",
+        "ref": "2026-04-29-agentic-coding-models-just-made-software-engineering-a-spect",
         "label": "Models hitting 70% on complex coding benchmarks means watching machines do our jobs"
       },
       {
         "type": "thought",
-        "ref": "2026-04-30-code-assistants-just-turned-programming-into-pair-programming-with-a-know-it-all",
+        "ref": "2026-04-30-code-assistants-just-turned-programming-into-pair-programmin",
         "label": "Programming with AI assistants fundamentally changes the development dynamic"
       }
     ],
@@ -341,17 +341,17 @@
     "evidence": [
       {
         "type": "news",
-        "ref": "2026-05-01",
+        "ref": "2026-05-01-ai-digest",
         "label": "Anthropic heads for a $900B valuation"
       },
       {
         "type": "news",
-        "ref": "2026-05-02",
+        "ref": "2026-05-02-ai-digest",
         "label": "Big tech splashes $725 billion on AI infrastructure"
       },
       {
         "type": "news",
-        "ref": "2026-04-25",
+        "ref": "2026-04-25-ai-digest",
         "label": "Google drops £40B on Anthropic"
       },
       {
@@ -378,12 +378,12 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-05-03",
+        "ref": "2026-05-03-remote-agents-just-made-the-desktop-obsolete",
         "label": "Remote agents just made the desktop obsolete"
       },
       {
         "type": "news",
-        "ref": "2026-05-03",
+        "ref": "2026-05-03-ai-digest",
         "label": "Mistral ships remote agents whilst regulators scramble"
       }
     ],
@@ -410,7 +410,7 @@
       },
       {
         "type": "news",
-        "ref": "2026-04-29",
+        "ref": "2026-04-29-ai-digest",
         "label": "OpenAI releases open-source privacy tools"
       }
     ],
@@ -464,17 +464,17 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-05-04-billion-dollar-valuations-just-turned-ai-companies-into-performance-art",
+        "ref": "2026-05-04-billion-dollar-valuations-just-turned-ai-companies-into-perf",
         "label": "Valuations disconnected from engineering reality"
       },
       {
         "type": "news",
-        "ref": "2026-05-01-ai-digest-valuations-gone-mad",
+        "ref": "2026-05-01-ai-digest",
         "label": "Anthropic heading for $900B valuation"
       },
       {
         "type": "news",
-        "ref": "2026-04-30-ai-digest-big-money-better-tools",
+        "ref": "2026-04-30-ai-digest",
         "label": "Anthropic massive funding round"
       }
     ],
@@ -496,7 +496,7 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-05-01-model-distillation-just-turned-training-into-intellectual-property-laundering",
+        "ref": "2026-05-01-model-distillation-just-turned-training-into-intellectual-pr",
         "label": "Distillation as standard knowledge transfer"
       },
       {
@@ -528,7 +528,7 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-05-02-sparse-autoencoders-just-turned-interpretability-into-feature-engineering",
+        "ref": "2026-05-02-sparse-autoencoders-just-turned-interpretability-into-featur",
         "label": "Sparse autoencoders turning interpretability into feature engineering"
       },
       {
@@ -592,12 +592,12 @@
       },
       {
         "type": "news",
-        "ref": "2026-05-06-ai-digest-voice-gets-real-agents-get-organised",
+        "ref": "2026-05-06-ai-digest",
         "label": "Voice AI finally starts listening to how we actually talk"
       },
       {
         "type": "news",
-        "ref": "2026-05-04-ai-digest-production-realities-bite",
+        "ref": "2026-05-04-ai-digest",
         "label": "Voice cloning breakthroughs"
       }
     ],
@@ -619,12 +619,12 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-05-06-webhooks-just-turned-every-ai-model-into-a-notification-addiction",
+        "ref": "2026-05-06-webhooks-just-turned-every-ai-model-into-a-notification-addi",
         "label": "Webhooks turn AI models into notification addiction"
       },
       {
         "type": "news",
-        "ref": "2026-05-06-ai-digest-voice-gets-real-agents-get-organised",
+        "ref": "2026-05-06-ai-digest",
         "label": "OpenAI ships a less hallucinogenic model and everyone builds agent frameworks"
       }
     ],
@@ -651,7 +651,7 @@
       },
       {
         "type": "thought",
-        "ref": "2026-05-09-spec-driven-development-just-turned-ai-coding-agents-into-actual-engineers",
+        "ref": "2026-05-09-spec-driven-development-just-turned-ai-coding-agents-into-ac",
         "label": "Spec-driven development just turned AI coding agents into actual engineers"
       }
     ],
@@ -678,7 +678,7 @@
       },
       {
         "type": "news",
-        "ref": "2026-05-08-ai-digest-infrastructure-week",
+        "ref": "2026-05-08-ai-digest",
         "label": "AI digest: Infrastructure week"
       }
     ],
@@ -705,7 +705,7 @@
       },
       {
         "type": "thought",
-        "ref": "2026-05-10-single-checkpoints",
+        "ref": "2026-05-10-single-checkpoints-just-turned-model-deployment-into-a-versi",
         "label": "Single checkpoints becoming deployment complexity"
       },
       {
@@ -764,22 +764,22 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-07",
+        "ref": "2026-06-07-command-line-interfaces-just-turned-ai-agents-into-unix-phil",
         "label": "Command line interfaces just turned AI agents into Unix philosophers"
       },
       {
         "type": "thought",
-        "ref": "2026-06-08",
+        "ref": "2026-06-08-command-line-agents-just-turned-every-developer-into-a-syste",
         "label": "Command-line agents just turned every developer into a system administrator"
       },
       {
         "type": "news",
-        "ref": "2026-06-07",
+        "ref": "2026-06-07-ai-digest",
         "label": "Tools go terminal: Command-line AI tools multiply"
       },
       {
         "type": "news",
-        "ref": "2026-06-08",
+        "ref": "2026-06-08-ai-digest",
         "label": "OpenAI declares chat dead whilst everyone rushes to build autonomous agents"
       }
     ],
@@ -802,17 +802,17 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-09",
+        "ref": "2026-06-09-security-scanning-just-turned-ai-model-repositories-into-haz",
         "label": "Security scanning just turned AI model repositories into hazmat disposal sites"
       },
       {
         "type": "news",
-        "ref": "2026-06-03",
+        "ref": "2026-06-03-ai-digest",
         "label": "AI security breaches shake up the week"
       },
       {
         "type": "news",
-        "ref": "2026-06-07",
+        "ref": "2026-06-07-ai-digest",
         "label": "security and politics heat up around major models"
       }
     ],
@@ -834,17 +834,17 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-10",
+        "ref": "2026-06-10-real-time-streaming-just-turned-ai-into-a-conversational-arm",
         "label": "Real-time streaming just turned AI into a conversational arms race"
       },
       {
         "type": "news",
-        "ref": "2026-06-09",
+        "ref": "2026-06-09-ai-digest",
         "label": "trillion-parameter models hit crazy speeds"
       },
       {
         "type": "news",
-        "ref": "2026-06-10",
+        "ref": "2026-06-10-ai-digest",
         "label": "Google ships real-time translation across 70 languages"
       }
     ],
@@ -867,7 +867,7 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-11",
+        "ref": "2026-06-11-same-model-different-masks-just-turned-ai-safety-into-market",
         "label": "Same model, different masks just turned AI safety into marketing theatre"
       },
       {
@@ -895,17 +895,17 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-07",
+        "ref": "2026-06-07-command-line-interfaces-just-turned-ai-agents-into-unix-phil",
         "label": "Command line interfaces just turned AI agents into Unix philosophers"
       },
       {
         "type": "thought",
-        "ref": "2026-06-08",
+        "ref": "2026-06-08-command-line-agents-just-turned-every-developer-into-a-syste",
         "label": "Command-line agents just turned every developer into a system administrator"
       },
       {
         "type": "news",
-        "ref": "2026-06-07",
+        "ref": "2026-06-07-ai-digest",
         "label": "AI digest: Tools go terminal"
       }
     ],
@@ -927,17 +927,17 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-04",
+        "ref": "2026-06-04-on-device-inference-just-turned-the-cloud-into-expensive-nos",
         "label": "On-device inference just turned the cloud into expensive nostalgia"
       },
       {
         "type": "thought",
-        "ref": "2026-06-06",
+        "ref": "2026-06-06-hybrid-routing-just-turned-your-laptop-into-a-schizophrenic-",
         "label": "Hybrid routing just turned your laptop into a schizophrenic cloud terminal"
       },
       {
         "type": "news",
-        "ref": "2026-06-04",
+        "ref": "2026-06-04-ai-digest",
         "label": "AI digest: Models go local, agents go mainstream"
       }
     ],
@@ -959,12 +959,12 @@
     "evidence": [
       {
         "type": "news",
-        "ref": "2026-06-21-ai-digest-agents-getting-smarter-models-getting-smaller",
+        "ref": "2026-06-21-ai-digest",
         "label": "Perplexity self-improving agent memory flagged in digest"
       },
       {
         "type": "thought",
-        "ref": "2026-06-21-agents-that-learn-from-their-own-mistakes-are-more-dangerous-than-agents-that-dont",
+        "ref": "2026-06-21-agents-that-learn-from-their-own-mistakes-are-more-dangerous",
         "label": "Self-improving agent memory as unmonitored risk"
       }
     ],
@@ -1051,7 +1051,7 @@
       },
       {
         "type": "news",
-        "ref": "2026-06-22",
+        "ref": "2026-06-22-ai-digest",
         "label": "AI digest: money, agents, and a grade inflation scandal"
       }
     ],
@@ -1074,12 +1074,12 @@
     "evidence": [
       {
         "type": "thought",
-        "ref": "2026-06-22",
+        "ref": "2026-06-22-government-bans-are-free-marketing-for-ai-labs",
         "label": "Government Bans Are Free Marketing for AI Labs"
       },
       {
         "type": "news",
-        "ref": "2026-06-21",
+        "ref": "2026-06-21-ai-digest",
         "label": "AI digest: agents getting smarter, models getting smaller"
       }
     ],
@@ -1112,7 +1112,7 @@
       },
       {
         "type": "news",
-        "ref": "2026-06-22",
+        "ref": "2026-06-22-ai-digest",
         "label": "AI digest: money, agents, and a grade inflation scandal"
       }
     ],


### PR DESCRIPTION
Follow-up to #175. That PR made evidence sources clickable and degraded broken refs to plain text. This fixes the **underlying data rot** and the bot that caused it, so the renderer's fallback is a safety net rather than a crutch.

## The bug

`node scripts/validate-horizon-refs.mjs` was **red — 48 errors**. Now-lane evidence refs pointed at no content file, in two flavours:

- **bare dates** — `"2026-06-10"` instead of the thought slug
- **over-long slugs** — the full untruncated headline, which doesn't match the truncated filename (`2026-04-29-...-spectator-sport` vs the on-disk `...-spect`)

**Root cause:** the Job 1 prompt fed the model `[date] title` for thoughts/news but never the actual slug, then asked it to emit that slug as `ref`. So it guessed.

## Fix

**Data** — rewrote all 48 refs in `now.json` to the real slug via unique leading-date match. Every one resolved cleanly (zero ambiguous, zero unresolvable). The diff is 48 ref-line swaps, no formatting churn. Validator now: **0 errors, 0 warnings**.

**Bot** (`horizon_bot.py`), defence in depth:
1. **Prompt** — each context item now leads with `ref=<stem>`, and the instruction says copy that token verbatim. No more guessing.
2. **`_sanitize_evidence()`** — resolves every model-supplied ref against the same context the model saw: rewrites a recoverable ref to its real slug, and **drops (with a log line) anything that points at nothing**. A broken ref can no longer reach `now.json`. Mirrors the validator and `src/lib/horizon-evidence.ts`.

## Verification

- `validate-horizon-refs.mjs` → 0 errors, 0 warnings
- `npm run build` green (828 pages)
- New `bot/tests/test_horizon_evidence.py` — 8 cases (exact slug kept; bare-date + over-long rewritten; unknown/ambiguous/unresolvable dropped; label preserved). **Full bot suite: 60 passed.**
- On the rendered page every thought/news ref now links; the only plain-text rows left are 18 April radar dates that fall outside the 30-day built window (legitimately have no page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)