### PR TITLE
feral: flip the autonomy dial from propose to ship

### DIFF
--- a/.github/workflows/feral.yml
+++ b/.github/workflows/feral.yml
@@ -23,7 +23,7 @@ on:
 # Start on `propose` for a few cycles. Once you've watched the council run and
 # trust the safety gate, flip this default to `ship`. That's the only change.
 env:
-  FERAL_MODE: ${{ github.event.inputs.mode || 'propose' }}
+  FERAL_MODE: ${{ github.event.inputs.mode || 'ship' }}
   # Runaway guard. Raise if cycles get cut off mid-build.
   FERAL_MAX_TURNS: "60"
 


### PR DESCRIPTION
Scheduled feral cycles now auto-merge to main once the gate passes (build + scope + critic PASS) — no human PR step. Run 3 (Fri 2026-06-26 07:00 UTC) will ship autonomously. `workflow_dispatch` can still override the mode per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)